### PR TITLE
Save errors on eta and vlss

### DIFF
--- a/bin/do_deltas.py
+++ b/bin/do_deltas.py
@@ -248,14 +248,14 @@ if __name__ == '__main__':
         if it < nit-1:
             ll_rest, mc, wmc = prep_del.mc(data)
             forest.mean_cont = interp1d(ll_rest[wmc>0.], forest.mean_cont(ll_rest[wmc>0.]) * mc[wmc>0.], fill_value = "extrapolate")
-            ll,eta,vlss,nb_pixels = prep_del.var_lss(data,(args.eta_min,args.eta_max),(args.vlss_min,args.vlss_max))
+            ll,eta,eta_err,vlss,vlss_err,nb_pixels = prep_del.var_lss(data,(args.eta_min,args.eta_max),(args.vlss_min,args.vlss_max))
             forest.eta = interp1d(ll[nb_pixels>0.], eta[nb_pixels>0.], fill_value = "extrapolate")
             forest.var_lss = interp1d(ll[nb_pixels>0.],vlss[nb_pixels>0.], fill_value = "extrapolate")
 
     res = fitsio.FITS(args.iter_out_prefix+".fits.gz",'rw',clobber=True)
     ll_st,st,wst = prep_del.stack(data)
     res.write([ll_st,st,wst],names=['loglam','stack','weight'])
-    res.write([ll,eta,vlss,nb_pixels],names=['loglam','eta','var_lss','nb_pixels'])
+    res.write([ll,eta,eta_err,vlss,vlss_err,nb_pixels],names=['loglam','eta','eta_err','var_lss','var_lss_err','nb_pixels'])
     res.write([ll_rest,forest.mean_cont(ll_rest),wmc],names=['loglam_rest','mean_cont','weight'])
     st = interp1d(ll_st[wst>0.],st[wst>0.],kind="nearest",fill_value="extrapolate")
     res.close()

--- a/py/picca/prep_del.py
+++ b/py/picca/prep_del.py
@@ -28,7 +28,9 @@ def mc(data):
 def var_lss(data,eta_lim=(0.5,1.5),vlss_lim=(0.,0.3)):
     nlss = 10
     eta = sp.zeros(nlss)
+    eta_err = sp.zeros(nlss)
     vlss = sp.zeros(nlss)
+    vlss_err = sp.zeros(nlss)
     nb_pixels = sp.zeros(nlss)
     ll = forest.lmin + (sp.arange(nlss)+.5)*(forest.lmax-forest.lmin)/nlss
 
@@ -90,12 +92,14 @@ def var_lss(data,eta_lim=(0.5,1.5),vlss_lim=(0.,0.3)):
         mig.migrad()
 
         eta[i] = mig.values["eta"]
+        eta_err[i] = mig.errors["eta"]
         vlss[i] = mig.values["vlss"]
+        vlss_err[i] = mig.errors["vlss"]
         nb_pixels[i] = count[i*nwe:(i+1)*nwe].sum()
-        print eta[i],vlss[i],mig.fval, nb_pixels[i]
+        print eta[i],eta_err[i],vlss[i],vlss_err[i],mig.fval,nb_pixels[i]
 
 
-    return ll,eta,vlss,nb_pixels
+    return ll,eta,eta_err,vlss,vlss_err,nb_pixels
 
     
 def stack(data,delta=False):


### PR DESCRIPTION
Extract the errors on the parameters eta and vlss and save to the output fits file. Tested on subsamples of Lya and CIV spectra.