### PR TITLE
refactored eta-vlss fit

### DIFF
--- a/bin/do_deltas.py
+++ b/bin/do_deltas.py
@@ -130,6 +130,7 @@ if __name__ == '__main__':
 
     forest.var_lss = interp1d(forest.lmin+sp.arange(2)*(forest.lmax-forest.lmin),0.2 + sp.zeros(2),fill_value="extrapolate")
     forest.eta = interp1d(forest.lmin+sp.arange(2)*(forest.lmax-forest.lmin), sp.ones(2),fill_value="extrapolate")
+    forest.fudge = interp1d(forest.lmin+sp.arange(2)*(forest.lmax-forest.lmin), sp.zeros(2),fill_value="extrapolate")
     forest.mean_cont = interp1d(forest.lmin_rest+sp.arange(2)*(forest.lmax_rest-forest.lmin_rest),1+sp.zeros(2))
 
     ### Fix the order of the continuum fit, 0 or 1. 
@@ -249,8 +250,9 @@ if __name__ == '__main__':
             ll_rest, mc, wmc = prep_del.mc(data)
             forest.mean_cont = interp1d(ll_rest[wmc>0.], forest.mean_cont(ll_rest[wmc>0.]) * mc[wmc>0.], fill_value = "extrapolate")
             ll,eta,vlss,fudge,nb_pixels,var,var_del,var2_del,count,nqsos,chi2 = prep_del.var_lss(data,(args.eta_min,args.eta_max),(args.vlss_min,args.vlss_max))
-            forest.eta = interp1d(ll[nb_pixels>0.], eta[nb_pixels>0.], fill_value = "extrapolate")
-            forest.var_lss = interp1d(ll[nb_pixels>0.],vlss[nb_pixels>0.], fill_value = "extrapolate")
+            forest.eta = interp1d(ll[nb_pixels>0], eta[nb_pixels>0], fill_value = "extrapolate")
+            forest.var_lss = interp1d(ll[nb_pixels>0], vlss[nb_pixels>0.], fill_value = "extrapolate")
+            forest.fudge = interp1d(ll[nb_pixels>0],fudge[nb_pixels>0], fill_value = "extrapolate")
 
     res = fitsio.FITS(args.iter_out_prefix+".fits.gz",'rw',clobber=True)
     ll_st,st,wst = prep_del.stack(data)

--- a/bin/do_deltas.py
+++ b/bin/do_deltas.py
@@ -248,15 +248,17 @@ if __name__ == '__main__':
         if it < nit-1:
             ll_rest, mc, wmc = prep_del.mc(data)
             forest.mean_cont = interp1d(ll_rest[wmc>0.], forest.mean_cont(ll_rest[wmc>0.]) * mc[wmc>0.], fill_value = "extrapolate")
-            ll,eta,vlss,nb_pixels = prep_del.var_lss(data,(args.eta_min,args.eta_max),(args.vlss_min,args.vlss_max))
+            ll,eta,vlss,fudge,nb_pixels,var,var_del,var2_del,count,nqsos,chi2 = prep_del.var_lss(data,(args.eta_min,args.eta_max),(args.vlss_min,args.vlss_max))
             forest.eta = interp1d(ll[nb_pixels>0.], eta[nb_pixels>0.], fill_value = "extrapolate")
             forest.var_lss = interp1d(ll[nb_pixels>0.],vlss[nb_pixels>0.], fill_value = "extrapolate")
 
     res = fitsio.FITS(args.iter_out_prefix+".fits.gz",'rw',clobber=True)
     ll_st,st,wst = prep_del.stack(data)
     res.write([ll_st,st,wst],names=['loglam','stack','weight'])
-    res.write([ll,eta,vlss,nb_pixels],names=['loglam','eta','var_lss','nb_pixels'])
+    res.write([ll,eta,vlss,fudge,nb_pixels],names=['loglam','eta','var_lss','fudge','nb_pixels'])
     res.write([ll_rest,forest.mean_cont(ll_rest),wmc],names=['loglam_rest','mean_cont','weight'])
+    var = sp.broadcast_to(var.reshape(1,-1),var_del.shape)
+    res.write([var,var_del,var2_del,count,nqsos,chi2],names=['var_pipe','var_del','var2_del','count','nqsos','chi2'])
     st = interp1d(ll_st[wst>0.],st[wst>0.],kind="nearest",fill_value="extrapolate")
     res.close()
     deltas = {}

--- a/bin/do_xdmat.py
+++ b/bin/do_xdmat.py
@@ -123,8 +123,10 @@ if __name__ == '__main__':
             dels[p].append(d)
 
             z = 10**d.ll/args.lambda_abs-1.
-            z_min_pix = sp.amin( sp.append([z_min_pix],z) )
-            z_max_pix = sp.amax( sp.append([z_max_pix],z) )
+            if z_min_pix > z.min():
+                z_min_pix = z.min()
+            if z_max_pix < z.max():
+                z_max_pix = z.max()
             d.r_comov = cosmo.r_comoving(z)
             d.we *= ((1.+z)/(1.+args.z_ref))**(xcf.alpha-1.)
         if not args.nspec is None:

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -4,6 +4,9 @@ from picca import constants
 import iminuit
 from dla import dla
 
+def variance(var,eta,var_lss,fudge):
+    return eta*var + var_lss + fudge/var
+
 class qso:
     def __init__(self,thid,ra,dec,zqso,plate,mjd,fiberid):
         self.ra = ra
@@ -145,6 +148,7 @@ class forest(qso):
 
         var_lss = forest.var_lss(self.ll)
         eta = forest.eta(self.ll)
+        fudge = forest.fudge(self.ll)
 
         def model(p0,p1):
             line = p1*(self.ll-lmin)/(lmax-lmin)+p0
@@ -152,8 +156,11 @@ class forest(qso):
 
         def chi2(p0,p1):
             m = model(p0,p1)
-            iv = self.iv/eta
-            we = iv/(iv*var_lss*m**2+1)
+            var = 1./self.iv/m**2
+            ## prep_del.variance is the variance of delta
+            ## we want here the we = ivar(flux)
+
+            we = 1/m**2/variance(var,eta,var_lss,fudge)
             v = (self.fl-m)**2*we
             return v.sum()-sp.log(we).sum()
 

--- a/py/picca/prep_del.py
+++ b/py/picca/prep_del.py
@@ -26,21 +26,23 @@ def mc(data):
     return ll,mcont,wcont
 
 def var_lss(data,eta_lim=(0.5,1.5),vlss_lim=(0.,0.3)):
-    nlss = 10
+    nlss = 20
     eta = sp.zeros(nlss)
     vlss = sp.zeros(nlss)
+    fudge = sp.zeros(nlss)
     nb_pixels = sp.zeros(nlss)
     ll = forest.lmin + (sp.arange(nlss)+.5)*(forest.lmax-forest.lmin)/nlss
 
     nwe = 100
     vpmin = sp.log10(1e-5)
     vpmax = sp.log10(2.)
-
     var = 10**(vpmin + (sp.arange(nwe)+.5)*(vpmax-vpmin)/nwe)
+
     var_del =sp.zeros(nlss*nwe)
     mdel =sp.zeros(nlss*nwe)
     var2_del =sp.zeros(nlss*nwe)
     count =sp.zeros(nlss*nwe)
+    nqso = sp.zeros(nlss*nwe)
 
     for p in data:
         for d in data[p]:
@@ -70,6 +72,8 @@ def var_lss(data,eta_lim=(0.5,1.5),vlss_lim=(0.,0.3)):
 
             c = sp.bincount(bins)
             count[:len(c)] += c
+            nqso[sp.unique(bins)]+=1
+
     
     w = count>0
     var_del[w]/=count[w]
@@ -79,23 +83,26 @@ def var_lss(data,eta_lim=(0.5,1.5),vlss_lim=(0.,0.3)):
     var2_del -= var_del**2
     var2_del[w]/=count[w]
 
+    bin_chi2 = sp.zeros(nlss)
     for i in range(nlss):
-        def chi2(eta,vlss):
-            v = var_del[i*nwe:(i+1)*nwe]-eta*var-vlss
+        def chi2(eta,vlss,fudge):
+            v = var_del[i*nwe:(i+1)*nwe]-eta*var-vlss-fudge/var
             dv2 = var2_del[i*nwe:(i+1)*nwe]
             n = count[i*nwe:(i+1)*nwe]
-            w=(dv2>0) & (n>100)
+            w=nqso[i*nwe:(i+1)*nwe]>100
             return sp.sum(v[w]**2/dv2[w])
-        mig = iminuit.Minuit(chi2,forced_parameters=("eta","vlss"),eta=1.,vlss=0.1,error_eta=0.05,error_vlss=0.05,errordef=1.,print_level=0,limit_eta=eta_lim,limit_vlss=vlss_lim)
+        mig = iminuit.Minuit(chi2,forced_parameters=("eta","vlss","fudge"),eta=1.,vlss=0.1,fudge=0.05,error_eta=0.05,error_vlss=0.05,error_fudge=0.05,errordef=1.,print_level=0,limit_eta=eta_lim,limit_vlss=vlss_lim, limit_fudge=(0,None))
         mig.migrad()
 
         eta[i] = mig.values["eta"]
         vlss[i] = mig.values["vlss"]
+        fudge[i] = mig.values["fudge"]
         nb_pixels[i] = count[i*nwe:(i+1)*nwe].sum()
-        print eta[i],vlss[i],mig.fval, nb_pixels[i]
+        bin_chi2[i] = mig.fval
+        print eta[i],vlss[i],fudge[i],mig.fval, nb_pixels[i]
 
 
-    return ll,eta,vlss,nb_pixels
+    return ll,eta,vlss,fudge,nb_pixels,var,var_del.reshape(nlss,-1),var2_del.reshape(nlss,-1),count.reshape(nlss,-1),nqso.reshape(nlss,-1),bin_chi2
 
     
 def stack(data,delta=False):

--- a/py/picca/prep_del.py
+++ b/py/picca/prep_del.py
@@ -33,10 +33,10 @@ def var_lss(data,eta_lim=(0.5,1.5),vlss_lim=(0.,0.3)):
     ll = forest.lmin + (sp.arange(nlss)+.5)*(forest.lmax-forest.lmin)/nlss
 
     nwe = 100
-    vpmin = 0
-    vpmax = 2
+    vpmin = sp.log10(1e-5)
+    vpmax = sp.log10(2.)
 
-    var = vpmin + (sp.arange(nwe)+.5)*(vpmax-vpmin)/nwe
+    var = 10**(vpmin + (sp.arange(nwe)+.5)*(vpmax-vpmin)/nwe)
     var_del =sp.zeros(nlss*nwe)
     mdel =sp.zeros(nlss*nwe)
     var2_del =sp.zeros(nlss*nwe)
@@ -46,10 +46,10 @@ def var_lss(data,eta_lim=(0.5,1.5),vlss_lim=(0.,0.3)):
         for d in data[p]:
 
             var_pipe = 1/d.iv/d.co**2
-            w = var_pipe < vpmax
+            w = (var_pipe > vpmin) & (var_pipe < vpmax)
 
             bll = ((d.ll-forest.lmin)/(forest.lmax-forest.lmin)*nlss).astype(int)
-            bwe = ((1/d.iv/d.co**2-vpmin)/(vpmax-vpmin)*nwe).astype(int)
+            bwe = sp.floor((sp.log10(var_pipe)-vpmin)/(vpmax-vpmin)*nwe).astype(int)
 
             bll = bll[w]
             bwe = bwe[w]


### PR DESCRIPTION
This branch addresses and issue reported offline by @mblomqvist which showed that for qso x civ the variance from picca was worse than for other codes. I tracked the problem down to a bias in the estimation of eta and vlss and refactored this fit to correct for this bias: I essentially switched to a log binning of the weights instead of a linear binning. 

