### PR TITLE
fix issue 48

### DIFF
--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -201,10 +201,12 @@ class delta(qso):
     @classmethod
     def from_forest(cls,f,st,var_lss,eta):
 
-        de = f.fl/f.co/st(f.ll)-1
+        de = f.fl/f.co/st(f.ll)-1.
+        mst = st(f.ll)
+        co = f.co
         ll = f.ll
         iv = f.iv/eta(f.ll)
-        we = iv*f.co**2/(iv*f.co**2*var_lss(f.ll)+1)
+        we = iv*(co*mst)**2/(iv*(co*mst)**2*var_lss(f.ll)+1)
         co = f.co
         return cls(f.thid,f.ra,f.dec,f.zqso,f.plate,f.mjd,f.fid,ll,we,co,de,f.order)
 


### PR DESCRIPTION
add missing \overline{F} to the definition of weight.
https://github.com/igmhub/picca/issues/48

Doesn't change much lya x qso:
(see the previous one minus the new one)
![diff_issue_48](https://user-images.githubusercontent.com/3166436/32474305-2620feb2-c329-11e7-94b1-3c602d110e07.png)

Doesn't change much the xi1d either
