### PR TITLE
add warning message if covariance matrix is not pos def

### DIFF
--- a/bin/export.py
+++ b/bin/export.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
     try:
         scipy.linalg.cholesky(co)
     except:
-        print("Matrix is not positive definite")
+        print("Warning: Matrix is not positive definite")
 
     if args.dmat is not None:
         h = fitsio.FITS(args.dmat)

--- a/bin/export.py
+++ b/bin/export.py
@@ -36,25 +36,6 @@ if __name__ == '__main__':
     we = sp.array(h[2]['WE'][:])
     hep = sp.array(h[2]['HEALPID'][:])
 
-    ### Remove empty healpix
-    w = sp.sum(we,axis=1)>0.
-    if w.sum()!=w.size:
-        print("Some healpix are empty, removing them: {}".format(hep[sp.logical_not(w)]))
-        da  = da[w,:]
-        we  = we[w,:]
-        hep = hep[w]
-
-    ### Remove healpix with empty pixels
-    w = sp.ones_like(hep).astype(bool)
-    for i,p in enumerate(hep):
-        if (we[i,:]<=0.).sum()!=0:
-            w[i] = False
-    if w.sum()!=w.size:
-        print("Some healpix have empty bins, removing them: {}".format(hep[sp.logical_not(w)]))
-        da  = da[w,:]
-        we  = we[w,:]
-        hep = hep[w]
-
     if args.cov is not None:
         hh = fitsio.FITS(args.cov)
         co = hh[1]['CO'][:]

--- a/bin/export.py
+++ b/bin/export.py
@@ -50,10 +50,9 @@ if __name__ == '__main__':
     if args.dmat is not None:
         h = fitsio.FITS(args.dmat)
         dm = h[1]['DM'][:]
+        h.close()
     else:
         dm = sp.eye(len(da))
-
-    h.close()
 
     h = fitsio.FITS(args.out,'rw',clobber=True)
 

--- a/bin/export.py
+++ b/bin/export.py
@@ -34,7 +34,23 @@ if __name__ == '__main__':
     nb  = sp.array(h[1]['NB'][:])
     da = sp.array(h[2]['DA'][:])
     we = sp.array(h[2]['WE'][:])
-    co = smooth_cov(da,we,rp,rt)
+    
+    if args.cov is not None:
+        hh = fitsio.FITS(args.cov)
+        co = hh[1]['CO'][:]
+        hh.close()
+    else:
+        head = h[1].read_header()
+        nt = head['NT']
+        np = head['NP']
+        rt_min = 0.
+        rt_max = head['RTMAX']
+        rp_min = head['RPMIN']
+        rp_max = head['RPMAX']
+        binSizeP = (rp_max-rp_min) / np
+        binSizeT = (rt_max-rt_min) / nt
+        co = smooth_cov(da,we,rp,rt,drt=binSizeT,drp=binSizeP)
+        
     da = (da*we).sum(axis=0)
     we = we.sum(axis=0)
     w = we>0

--- a/bin/export.py
+++ b/bin/export.py
@@ -2,8 +2,9 @@
 
 import fitsio
 import scipy as sp
-
+import scipy.linalg
 import argparse
+
 from picca.utils import smooth_cov
 
 
@@ -40,6 +41,11 @@ if __name__ == '__main__':
     da[w]/=we[w]
 
     h.close()
+
+    try:
+        scipy.linalg.cholesky(co)
+    except:
+        print("Matrix is not positive definite")
 
     if args.dmat is not None:
         h = fitsio.FITS(args.dmat)


### PR DESCRIPTION
Simply add a warning message when computing the covariance matrix.
passes tests.
@ngbusca, By the way, I don't know if you knew but the `--cov` argument doesn't do anything.
Do you want me to correct this?
