### PR TITLE
compare nside of both correlations

### DIFF
--- a/bin/export_cross_covariance.py
+++ b/bin/export_cross_covariance.py
@@ -29,15 +29,21 @@ if __name__ == '__main__':
         h = fitsio.FITS(p)
         head = h[1].read_header()
         nside = head['NSIDE']
+        head = h[2].read_header()
+        scheme = head['HLPXSCHM']
         da  = sp.array(h[2]['DA'][:])
         we  = sp.array(h[2]['WE'][:])
         hep = sp.array(h[2]['HEALPID'][:])
-        data[i] = {'DA':da, 'WE':we, 'HEALPID':hep, 'NSIDE':nside}
+        data[i] = {'DA':da, 'WE':we, 'HEALPID':hep, 'NSIDE':nside, 'HLPXSCHM':scheme}
         h.close()
 
     ### exit if NSIDE1!=NSIDE2
     if data[0]['NSIDE']!=data[1]['NSIDE']:
         print("ERROR: NSIDE are different: {} != {}".format(data[0]['NSIDE'],data[1]['NSIDE']))
+        sys.exit()
+    ### exit if HLPXSCHM1!=HLPXSCHM2
+    if data[0]['HLPXSCHM']!=data[1]['HLPXSCHM']:
+        print("ERROR: HLPXSCHM are different: {} != {}".format(data[0]['HLPXSCHM'],data[1]['HLPXSCHM']))
         sys.exit()
 
     ### Add unshared healpix as empty data

--- a/bin/export_cross_covariance.py
+++ b/bin/export_cross_covariance.py
@@ -4,6 +4,7 @@ import scipy as sp
 import scipy.linalg
 import fitsio
 import argparse
+import sys
 
 from picca.utils import cov
 
@@ -26,11 +27,18 @@ if __name__ == '__main__':
     ### Read data
     for i,p in enumerate([args.data1,args.data2]):
         h = fitsio.FITS(p)
+        head = h[1].read_header()
+        nside = head['NSIDE']
         da  = sp.array(h[2]['DA'][:])
         we  = sp.array(h[2]['WE'][:])
         hep = sp.array(h[2]['HEALPID'][:])
-        data[i] = {'DA':da, 'WE':we, 'HEALPID':hep}
+        data[i] = {'DA':da, 'WE':we, 'HEALPID':hep, 'NSIDE':nside}
         h.close()
+
+    ### exit if NSIDE1!=NSIDE2
+    if data[0]['NSIDE']!=data[1]['NSIDE']:
+        print("ERROR: NSIDE are different: {} != {}".format(data[0]['NSIDE'],data[1]['NSIDE']))
+        sys.exit()
 
     ### Add unshared healpix as empty data
     for i in sorted(list(data.keys())):


### PR DESCRIPTION
This PR adds a comparison between the nside of the two correlations.
If the nside are different, the code can not compute a cross-covariance.
Fixes https://github.com/igmhub/picca/issues/304