### PR TITLE
add option minos and storing minimum attributes

### DIFF
--- a/bin/fitter2
+++ b/bin/fitter2
@@ -7,5 +7,6 @@ import sys
 dic_init = parser.parse_chi2(sys.argv[1])
 chi = chi2.chi2(dic_init)
 chi.minimize()
+chi.minos()
 chi.fastMC()
 chi.export()

--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -109,7 +109,7 @@ class chi2:
         if not hasattr(self,"minos_para"): return
 
         sigma = self.minos_para['sigma']
-        if '_all_' in self.minos_para['parameters']:
+        if 'all' in self.minos_para['parameters']:
             self.best_fit.minos(var=None,sigma=sigma)
         else:
             for var in self.minos_para['parameters']:
@@ -145,17 +145,16 @@ class chi2:
         g.attrs['list of free pars'] = self.best_fit.list_of_vary_param()
         g.attrs['list of fixed pars'] = self.best_fit.list_of_fixed_param()
 
+        ## write down all attributes of the minimum
+        dic_fmin = utils.convert_instance_to_dictionary(self.best_fit.get_fmin())
+        for item, value in dic_fmin.items():
+            g.attrs[item] = value
+
         for d in self.data:
             g = f.create_group(d.name)
             g.attrs['chi2'] = d.chi2(self.k, self.pk_lin, self.pksb_lin, self.best_fit.values)
             fit = g.create_dataset("fit", d.da.shape, dtype = "f")
             fit[...] = d.best_fit_model
-
-        ## write down all attributes of the minimum
-        g = f.create_group("minimum")
-        dic_fmin = utils.convert_instance_to_dictionary(self.best_fit.get_fmin())
-        for item, value in dic_fmin.items():
-            g.attrs[item] = value
 
         if hasattr(self, "fast_mc"):
             g = f.create_group("fast mc")
@@ -169,6 +168,7 @@ class chi2:
         ## write down all attributes of parameters minos was run over
         if hasattr(self, "minos_para"):
             g = f.create_group("minos")
+            g.attrs['sigma'] = self.minos_para['sigma']
             minos_results = self.best_fit.get_merrors()
             for par in list(minos_results.keys()):
                 subgrp = g.create_group(par)

--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -137,7 +137,6 @@ class chi2:
         for (p1, p2), cov in self.best_fit.covariance.items():
             g.attrs["cov[{}, {}]".format(p1,p2)] = cov
 
-        g.attrs['fval'] = self.best_fit.fval
         ndata = [d.mask.sum() for d in self.data]
         ndata = sum(ndata)
         g.attrs['ndata'] = ndata

--- a/py/picca/fitter2/parser.py
+++ b/py/picca/fitter2/parser.py
@@ -31,6 +31,15 @@ def parse_chi2(filename):
         for item, value in cp.items('fast mc'):
             dic_init['fast mc'][item] = int(value)
 
+    if cp.has_section('minos'):
+        dic_init['minos'] = {}
+        for item, value in cp.items('minos'):
+            if item=='sigma':
+                value = float(value)
+            elif item=='parameters':
+                value = value.split()
+            dic_init['minos'][item] = value
+
     return dic_init
 
 def parse_data(filename):

--- a/py/picca/fitter2/utils.py
+++ b/py/picca/fitter2/utils.py
@@ -79,4 +79,6 @@ def bias_beta(kwargs, tracer1, tracer2):
 
     return bias1, beta1, bias2, beta2
 
-    
+def convert_instance_to_dictionary(inst):
+    dic = dict((name, getattr(inst, name)) for name in dir(inst) if not name.startswith('__'))
+    return dic


### PR DESCRIPTION
This PR adds in fitter2:
    - the storage of the `self.best_fit.get_fmin()` attributes. i.e. `is_valid`, `fval`, `has_pos_def_covar`, ...
    - an option to run minos on given parameters. As in fitter1, `_all_` runs on all
    This is done through adding the following lines in the file given to fitter2:
```
[minos]
sigma = 1.0 <or> 2.
parameters = _all_ <or> param1 param2
```

This PR aims at getting the same results we stored in fitter1.
The next step is running a chi2 scan.
@ngbusca, Don't hesitate to ask me to change anything 