### PR TITLE
Refactor diff

### DIFF
--- a/bin/do_deltas.py
+++ b/bin/do_deltas.py
@@ -396,10 +396,11 @@ if __name__ == '__main__':
                     hd["MEANRESO"]=d.mean_reso
                     hd["MEANSNR"]=d.mean_SNR
                     hd["DLL"]=d.dll
+                    diff = d.diff
+                    if diff is None:
+                        diff = d.ll*0
 
-
-                if (args.delta_format=='Pk1D') :
-                    cols=[d.ll,d.de,d.iv,d.diff]
+                    cols=[d.ll,d.de,d.iv,diff]
                     names=['LOGLAM','DELTA','IVAR','DIFF']
                 else :
                     cols=[d.ll,d.de,d.we,d.co]

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -130,12 +130,12 @@ class forest(qso):
         self.fl = fl
         self.iv = iv
         self.order = order
-        if diff is not None :
-            self.diff = diff
-            self.reso = reso
-        else :
-            self.diff = sp.zeros(len(ll))
-            self.reso = sp.ones(len(ll))
+        #if diff is not None :
+        self.diff = diff
+        self.reso = reso
+#        else :
+#           self.diff = sp.zeros(len(ll))
+#           self.reso = sp.ones(len(ll))
 
         # compute means
         if reso is not None : self.mean_reso = sum(reso)/float(len(reso))
@@ -300,7 +300,9 @@ class delta(qso):
         de = f.fl/(co*mst)-1.
         var = 1./f.iv/(co*mst)**2
         we = 1./variance(var,eta,var_lss,fudge)
-        diff = f.diff/(co*mst)
+        diff = f.diff
+        if f.diff is not None:
+            diff /= co*mst
         iv = f.iv/(eta+(eta==0))*(co**2)*(mst**2)
 
         return cls(f.thid,f.ra,f.dec,f.zqso,f.plate,f.mjd,f.fid,ll,we,co,de,f.order,


### PR DESCRIPTION
The  fact that the diff field does not get coadded over multiple observations was causing a crash when reading from spplates. I have refactored the diff and reso fields such that they stay None as the default value. This avoids the crash but I don't know if it breaks something on the Pk1D side (it doesn't break the unittests).