### PR TITLE
add storing grid parameter

### DIFF
--- a/bin/export.py
+++ b/bin/export.py
@@ -43,7 +43,6 @@ if __name__ == '__main__':
     head = h[1].read_header()
     nt = head['NT']
     np = head['NP']
-    rt_min = 0.
     rt_max = head['RTMAX']
     rp_min = head['RPMIN']
     rp_max = head['RPMAX']
@@ -55,7 +54,7 @@ if __name__ == '__main__':
         hh.close()
     else:
         binSizeP = (rp_max-rp_min) / np
-        binSizeT = (rt_max-rt_min) / nt
+        binSizeT = (rt_max-0.) / nt
         if not args.do_not_smooth_cov:
             print('INFO: The covariance will be smoothed')
             co = smooth_cov(da,we,rp,rt,drt=binSizeT,drp=binSizeP)

--- a/bin/export.py
+++ b/bin/export.py
@@ -40,18 +40,20 @@ if __name__ == '__main__':
     we = sp.array(h[2]['WE'][:])
     hep = sp.array(h[2]['HEALPID'][:])
 
+    head = h[1].read_header()
+    nt = head['NT']
+    np = head['NP']
+    rt_min = 0.
+    rt_max = head['RTMAX']
+    rp_min = head['RPMIN']
+    rp_max = head['RPMAX']
+    h.close()
+
     if args.cov is not None:
         hh = fitsio.FITS(args.cov)
         co = hh[1]['CO'][:]
         hh.close()
     else:
-        head = h[1].read_header()
-        nt = head['NT']
-        np = head['NP']
-        rt_min = 0.
-        rt_max = head['RTMAX']
-        rp_min = head['RPMIN']
-        rp_max = head['RPMAX']
         binSizeP = (rp_max-rp_min) / np
         binSizeT = (rt_max-rt_min) / nt
         if not args.do_not_smooth_cov:
@@ -66,8 +68,6 @@ if __name__ == '__main__':
     w = we>0
     da[w]/=we[w]
 
-    h.close()
-
     try:
         scipy.linalg.cholesky(co)
     except:
@@ -81,6 +81,11 @@ if __name__ == '__main__':
         dm = sp.eye(len(da))
 
     h = fitsio.FITS(args.out,'rw',clobber=True)
-
-    h.write([rp,rt,z,da,co,dm,nb],names=['RP','RT','Z','DA','CO','DM','NB'])
+    head = {}
+    head['RPMIN'] = rp_min
+    head['RPMAX'] = rp_max
+    head['RTMAX'] = rt_max
+    head['NT'] = nt
+    head['NP'] = np
+    h.write([rp,rt,z,da,co,dm,nb],names=['RP','RT','Z','DA','CO','DM','NB'],header=head)
     h.close()

--- a/bin/export_co.py
+++ b/bin/export_co.py
@@ -33,7 +33,6 @@ if __name__ == '__main__':
         sys.exit()
     nt = head['NT']
     np = head['NP']
-    rt_min = 0.
     rt_max = head['RTMAX']
     rp_min = head['RPMIN']
     rp_max = head['RPMAX']

--- a/bin/export_co.py
+++ b/bin/export_co.py
@@ -31,6 +31,12 @@ if __name__ == '__main__':
         print("ERROR: DD-file is not data-data : "+type_corr)
         h.close()
         sys.exit()
+    nt = head['NT']
+    np = head['NP']
+    rt_min = 0.
+    rt_max = head['RTMAX']
+    rp_min = head['RPMIN']
+    rp_max = head['RPMAX']
     nbObj = head['NOBJ']
     rp = sp.array(h[1]['RP'][:])
     rt = sp.array(h[1]['RT'][:])
@@ -109,5 +115,11 @@ if __name__ == '__main__':
 
     ### Save
     h = fitsio.FITS(args.out,'rw',clobber=True)
-    h.write([rp,rt,z,da,co,dm,nb],names=['RP','RT','Z','DA','CO','DM','NB'])
+    head = {}
+    head['RPMIN'] = rp_min
+    head['RPMAX'] = rp_max
+    head['RTMAX'] = rt_max
+    head['NT'] = nt
+    head['NP'] = np
+    h.write([rp,rt,z,da,co,dm,nb],names=['RP','RT','Z','DA','CO','DM','NB'],header=head)
     h.close()


### PR DESCRIPTION
Add storing grid parameters (i.e. `RPMIN, RPMAX, RTMAX, NP, NT`) to exported files.
This is for two reasons:
- will help solving issue https://github.com/igmhub/picca/issues/328 if we decide to cut on the center of the grid
- thanks to this PR all useful infos of the correlation are in the exported file. This is useful for plotting, no need to read one file for the grid and another for the errors. 