### PR TITLE
Growth factor with Dark Energy

### DIFF
--- a/py/picca/fitter2/xi.py
+++ b/py/picca/fitter2/xi.py
@@ -134,7 +134,7 @@ def cache_growth_factor_de(function):
             cache[pair] = (Om, OL)
             cache[1] = cached_growth_factor_de(*args, **kwargs)
         
-        return cache[1](args[0])
+        return cache[1](args[0])/cache[1](kwargs['zref'])
             
     return wrapper
 
@@ -168,10 +168,8 @@ def cached_growth_factor_de(z, zref = None, **kwargs):
         a = 1/(1+z[i])
         D1[i] = 5/2.*Om*hubble(z[i], *pars)*quad(dD1, 0, a, args=pars)[0]
 
-    D1_interp = interp1d(z, D1)
-    D1_ref = D1_interp(zref)
-    D1_interp = interp1d(z, D1/D1_ref)
-    return D1_interp
+    D1 = interp1d(z, D1)
+    return D1
 
 ### Lya bias evolution
 def bias_vs_z_std(z, tracer, zref = None, **kwargs):

--- a/py/picca/test/data/config_cf.ini
+++ b/py/picca/test/data/config_cf.ini
@@ -23,7 +23,7 @@ mu-max = 1.
 model-pk = pk_kaiser
 model-xi = cached_xi_kaiser
 z evol LYA = bias_vs_z_std
-growth function = growth_function_no_de
+growth function = growth_factor_no_de
 
 [metals]
 filename = <empty>

--- a/py/picca/test/data/config_cf_cross.ini
+++ b/py/picca/test/data/config_cf_cross.ini
@@ -23,7 +23,7 @@ mu-max = 1.
 model-pk = pk_kaiser
 model-xi = cached_xi_kaiser
 z evol LYA = bias_vs_z_std
-growth function = growth_function_no_de
+growth function = growth_factor_no_de
 
 [metals]
 filename = <empty>

--- a/py/picca/test/data/config_xcf.ini
+++ b/py/picca/test/data/config_xcf.ini
@@ -24,7 +24,7 @@ model-pk = pk_kaiser
 model-xi = xi_drp
 z evol LYA = bias_vs_z_std
 z evol QSO = qso_bias_vs_z_croom
-growth function = growth_function_no_de
+growth function = growth_factor_no_de
 
 [metals]
 filename = <empty>


### PR DESCRIPTION
This PR implements the growth_factor_de function to allow for growth_factors for arbitrary Om and OL.

There are two main changes:
  * I've changed the name `growth_function_no_de` to `growth_factor_no_de` of the old function (so users will have to update their .ini)
  * The new function `growth_factor_de` requires the values of `Om` and `OL`. The user would have to specify them in the list of parameters.

@londumas can you take a look? This should be useful for your low-z analyses. 