### PR TITLE
replace chararray by char

### DIFF
--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -141,7 +141,7 @@ def desi_from_ztarget_to_drq(ztarget,drq,spectype="QSO"):
     plate = 1+sp.arange(thid.size)
     mjd   = 1+sp.arange(thid.size)
     fid   = 1+sp.arange(thid.size)
-    sptype = sp.chararray.strip(vac[1]["SPECTYPE"][:].astype(str))
+    sptype = sp.char.strip(vac[1]["SPECTYPE"][:].astype(str))
 
     ## Sanity
     print(" start               : nb object in cat = {}".format(ra.size) )


### PR DESCRIPTION
As reported by @Cyeche, there can a crash with using `chararray`. `char` works on all platforms.
The reason seems to be: https://docs.scipy.org/doc/numpy/reference/generated/numpy.chararray.html
@Cyeche, can you do this simple review?