### PR TITLE
Add gaussian priors

### DIFF
--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -235,7 +235,8 @@ class chi2:
         g.attrs['npar'] = len(self.best_fit.list_of_vary_param())
         g.attrs['list of free pars'] = [a.encode('utf8') for a in self.best_fit.list_of_vary_param()]
         g.attrs['list of fixed pars'] = [a.encode('utf8') for a in self.best_fit.list_of_fixed_param()]
-        g.attrs['list of prior pars'] = [a.encode('utf8') for a in priors.prior_dic.keys()]
+        if len(priors.prior_dic) != 0:
+            g.attrs['list of prior pars'] = [a.encode('utf8') for a in priors.prior_dic.keys()]
 
         ## write down all attributes of the minimum
         dic_fmin = utils.convert_instance_to_dictionary(self.best_fit.get_fmin())

--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -228,6 +228,10 @@ class chi2:
         for (p1, p2), cov in self.best_fit.covariance.items():
             g.attrs["cov[{}, {}]".format(p1,p2)] = cov
 
+        if len(priors.prior_dic) != 0:
+            for prior in priors.prior_dic.values():
+                g.attrs["prior[{}]".format(prior.keywords['name'])] = (prior.keywords['prior_pars'][0],prior.keywords['prior_pars'][1],prior.func.__name__.encode('utf8'))
+        
         ndata = [d.mask.sum() for d in self.data]
         ndata = sum(ndata)
         g.attrs['zeff'] = self.zeff

--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -231,7 +231,7 @@ class chi2:
         if len(priors.prior_dic) != 0:
             for prior in priors.prior_dic.values():
                 g.attrs["prior[{}]".format(prior.keywords['name'])] = (prior.keywords['prior_pars'][0],prior.keywords['prior_pars'][1],prior.func.__name__.encode('utf8'))
-        
+
         ndata = [d.mask.sum() for d in self.data]
         ndata = sum(ndata)
         g.attrs['zeff'] = self.zeff

--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -7,7 +7,7 @@ import h5py
 from scipy.linalg import cholesky
 from scipy import random
 
-from . import utils
+from . import utils, priors
 
 def _wrap_chi2(d, dic=None, k=None, pk=None, pksb=None):
     return d.chi2(k, pk, pksb, dic)
@@ -41,6 +41,9 @@ class chi2:
         chi2 = 0
         for d in self.data:
             chi2 += d.chi2(self.k,self.pk_lin,self.pksb_lin,dic)
+
+        for prior in priors.prior_dic.values():
+            chi2 += prior(dic)
 
         if self.verbosity == 1:
             del dic['SB']
@@ -232,6 +235,7 @@ class chi2:
         g.attrs['npar'] = len(self.best_fit.list_of_vary_param())
         g.attrs['list of free pars'] = [a.encode('utf8') for a in self.best_fit.list_of_vary_param()]
         g.attrs['list of fixed pars'] = [a.encode('utf8') for a in self.best_fit.list_of_fixed_param()]
+        g.attrs['list of prior pars'] = [a.encode('utf8') for a in priors.prior_dic.keys()]
 
         ## write down all attributes of the minimum
         dic_fmin = utils.convert_instance_to_dictionary(self.best_fit.get_fmin())

--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -230,7 +230,10 @@ class chi2:
 
         if len(priors.prior_dic) != 0:
             for prior in priors.prior_dic.values():
-                g.attrs["prior[{}]".format(prior.keywords['name'])] = (prior.keywords['prior_pars'][0],prior.keywords['prior_pars'][1],prior.func.__name__.encode('utf8'))
+                values = [prior.func.__name__.encode('utf8')]
+                for value in prior.keywords['prior_pars']:
+                    values.append(value)
+                g.attrs["prior[{}]".format(prior.keywords['name'])] = values
 
         ndata = [d.mask.sum() for d in self.data]
         ndata = sum(ndata)

--- a/py/picca/fitter2/parser.py
+++ b/py/picca/fitter2/parser.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from functools import partial
 import sys
 import scipy as sp
 import os.path
@@ -11,7 +12,7 @@ else:
     import ConfigParser
 
 import fitsio
-from . import data, utils
+from . import data, utils, priors
 
 def parse_chi2(filename):
     cp = ConfigParser.ConfigParser()
@@ -123,6 +124,13 @@ def parse_data(filename,zeff,fiducial):
             dic_init['metals']['in tracer1'] = dic_init['metals']['in tracer1'].split()
         if 'in tracer2' in dic_init['metals']:
             dic_init['metals']['in tracer2'] = dic_init['metals']['in tracer2'].split()
+
+    if 'priors' in cp.sections():
+        for item, value in cp.items('priors'):
+            if item in priors.prior_dic.keys():
+                print("WARNING: prior on {} will be overwritten".format(item))
+            value = value.split()
+            priors.prior_dic[item] = partial(getattr(priors, value[2]), prior_pars=(float(value[0]),float(value[1])), name=item)
 
     return dic_init
 

--- a/py/picca/fitter2/parser.py
+++ b/py/picca/fitter2/parser.py
@@ -130,7 +130,7 @@ def parse_data(filename,zeff,fiducial):
             if item in priors.prior_dic.keys():
                 print("WARNING: prior on {} will be overwritten".format(item))
             value = value.split()
-            priors.prior_dic[item] = partial(getattr(priors, value[2]), prior_pars=(float(value[0]),float(value[1])), name=item)
+            priors.prior_dic[item] = partial(getattr(priors, value[0]), prior_pars=sp.array(value[1:]).astype(float), name=item)
 
     return dic_init
 

--- a/py/picca/fitter2/priors.py
+++ b/py/picca/fitter2/priors.py
@@ -1,0 +1,8 @@
+
+prior_dic = {}
+
+def gaussian(pars, prior_pars=None, name=None):
+    mu = prior_pars[0]
+    sigma = prior_pars[1]
+    par = pars[name]
+    return (par-mu)**2/sigma**2


### PR DESCRIPTION
This PR adds the option to apply gaussian priors on fit parameters. It's easy to add other types of priors in priors.py in future updates. Set the gaussian prior in the correlation ini file with e.g.

[priors]
beta_hcd = 0.5 0.2 gaussian

Prints a warning if the same prior is set in multiple ini files. The way the code is set up, only the parameter names are saved in 'list of prior pars'. Do we want to change that?