### PR TITLE
correct bug when no tracer in traceri

### DIFF
--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -142,7 +142,7 @@ class data:
             if 'in tracer1' in dic_init['metals']:
                 for m in dic_init['metals']['in tracer1']:
                     self.tracerMet[m] = { 'name':m, 'type':'continuous' }
-            if 'in tracer2' in dic_init['metals']
+            if 'in tracer2' in dic_init['metals']:
                 for m in dic_init['metals']['in tracer2']:
                     self.tracerMet[m] = { 'name':m, 'type':'continuous' }
 

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -139,10 +139,12 @@ class data:
             self.tracerMet = {}
             self.tracerMet[self.tracer1['name']] = self.tracer1
             self.tracerMet[self.tracer2['name']] = self.tracer2
-            for m in dic_init['metals']['in tracer1']:
-                self.tracerMet[m] = { 'name':m, 'type':'continuous' }
-            for m in dic_init['metals']['in tracer2']:
-                self.tracerMet[m] = { 'name':m, 'type':'continuous' }
+            if 'in tracer1' in dic_init['metals']:
+                for m in dic_init['metals']['in tracer1']:
+                    self.tracerMet[m] = { 'name':m, 'type':'continuous' }
+            if 'in tracer2' in dic_init['metals']
+                for m in dic_init['metals']['in tracer2']:
+                    self.tracerMet[m] = { 'name':m, 'type':'continuous' }
 
             hmet = fitsio.FITS(dic_init['metals']['filename'])
 

--- a/py/picca/test/data/config_xcf.ini
+++ b/py/picca/test/data/config_xcf.ini
@@ -32,7 +32,6 @@ filename = <empty>
 model-pk-met = pk_kaiser
 model-xi-met = xi_drp
 z evol       = bias_vs_z_std
-in tracer1 = 
 in tracer2 = SiIII(1207)
 
 [parameters]


### PR DESCRIPTION
Correct bug https://github.com/igmhub/picca/issues/394.
Reads `in traceri` only if it exists.