### PR TITLE
test required version of module against local version

### DIFF
--- a/py/picca/test/test_cor.py
+++ b/py/picca/test/test_cor.py
@@ -45,6 +45,8 @@ class TestCor(unittest.TestCase):
 
     def test_cor(self):
 
+        self.test_requirements()
+
         numpy.random.seed(42)
 
         print("\n")
@@ -302,11 +304,32 @@ class TestCor(unittest.TestCase):
                 compare_values(m[k][p]['values'].value,b[k][p]['values'].value)
 
         return
+    def load_requirements(self):
+
+        req = {}
+
+        path = resource_filename('picca', '/../../requirements.txt')
+        for l in open(path,'r'):
+            l = l.replace('\n','').split('==')
+            if len(l)!=2: continue
+            req[l[0]] = l[1]
+
+        return req
 
 
 
 
 
+    def test_requirements(self):
+
+        print("\n")
+        req = self.load_requirements()
+        for req_lib, req_ver in req.iteritems():
+            local_ver = __import__(req_lib).__version__
+            if local_ver!=req_ver:
+                print("WARNING: The local version of {}: {} is different from the required version: {}".format(req_lib,local_ver,req_ver))
+
+        return
 
 
     def send_delta(self):

--- a/py/picca/test/test_cor.py
+++ b/py/picca/test/test_cor.py
@@ -324,7 +324,7 @@ class TestCor(unittest.TestCase):
 
         print("\n")
         req = self.load_requirements()
-        for req_lib, req_ver in req.iteritems():
+        for req_lib, req_ver in req.items():
             local_ver = __import__(req_lib).__version__
             if local_ver!=req_ver:
                 print("WARNING: The local version of {}: {} is different from the required version: {}".format(req_lib,local_ver,req_ver))

--- a/py/picca/test/test_cor.py
+++ b/py/picca/test/test_cor.py
@@ -311,7 +311,7 @@ class TestCor(unittest.TestCase):
         path = resource_filename('picca', '/../../requirements.txt')
         for l in open(path,'r'):
             l = l.replace('\n','').split('==')
-            if len(l)!=2: continue
+            self.assertTrue(len(l)==2,"requirements.txt attribute is not valid: {}".format(str(l)))
             req[l[0]] = l[1]
 
         return req
@@ -325,7 +325,10 @@ class TestCor(unittest.TestCase):
         print("\n")
         req = self.load_requirements()
         for req_lib, req_ver in req.items():
-            local_ver = __import__(req_lib).__version__
+            try:
+                local_ver = __import__(req_lib).__version__
+            except:
+                print("WARNING: Module {} can't be found".format(req_lib))
             if local_ver!=req_ver:
                 print("WARNING: The local version of {}: {} is different from the required version: {}".format(req_lib,local_ver,req_ver))
 

--- a/py/picca/test/test_cor.py
+++ b/py/picca/test/test_cor.py
@@ -327,10 +327,10 @@ class TestCor(unittest.TestCase):
         for req_lib, req_ver in req.items():
             try:
                 local_ver = __import__(req_lib).__version__
-            except:
+                if local_ver!=req_ver:
+                    print("WARNING: The local version of {}: {} is different from the required version: {}".format(req_lib,local_ver,req_ver))
+            except ImportError:
                 print("WARNING: Module {} can't be found".format(req_lib))
-            if local_ver!=req_ver:
-                print("WARNING: The local version of {}: {} is different from the required version: {}".format(req_lib,local_ver,req_ver))
 
         return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ healpy==1.11
 fitsio==0.9.11
 numba==0.35.0
 h5py==2.6.0
-future
+future==0.16.0
 setuptools==27.2.0


### PR DESCRIPTION
test required version of module against local version.
Fix issue https://github.com/igmhub/picca/issues/396.

@ngbusca, what should we do for:
- newer version? I think we should still keep the warning
- for `future`? What is the purpose of this in the `requirements.txt`
- if the module is not installed?