### PR TITLE
read transmission files

### DIFF
--- a/bin/do_xcf.py
+++ b/bin/do_xcf.py
@@ -113,6 +113,7 @@ if __name__ == '__main__':
     xcf.ndels = ndels
     sys.stderr.write("\n")
     print("done, npix = {}\n".format(xcf.npix))
+    print("ndata = {}\n".format(xcf.ndels))
 
     ### Remove <delta> vs. lambda_obs
     if not args.no_remove_mean_lambda_obs:


### PR DESCRIPTION
This is an initial PR to read the transmission files in desi mocks.
```
do_xcf.py --in-dir BLABLA --drq Catalog/zcat_desi_drq.fits
--from-image /global/projecta/projectdirs/desi/mocks/lya_forest/london/v1.1/*/*/*
--out Correlations__transmission/xcf.fits.gz
--no-project
--nspec 10000
```
The array layout in London and Sacaly mocks are different:
[nPixels, nQSO] in London, [nQSO, nPixels ] in Saclay
Saclay mocks don't have extname.

We have to figure out a way to cut the transmission to the relevant lambda_RF range.
Currently I set a hard cut of 1215.67. This work for London mocks but not for Saclay mocks
since the transmission there is 1 at lambda_RF < 1025.73 A