### PR TITLE
convert transmission to delta files

### DIFF
--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -190,7 +190,7 @@ def desi_convert_transmission_to_delta_files(indir,outdir,lObs_min=3600.,lObs_ma
         fi = glob.glob(indir)
     else:
         fi = glob.glob(indir+'/*.fits') + glob.glob(indir+'/*.fits.gz')
-    fi = sorted(sp.array(fi))
+    fi = sp.sort(sp.array(fi))
 
     ### Stack the transmission
     lmin = sp.log10(lObs_min)
@@ -202,7 +202,8 @@ def desi_convert_transmission_to_delta_files(indir,outdir,lObs_min=3600.,lObs_ma
     deltas = {}
 
     ### Read
-    for f in fi:
+    for nf, f in enumerate(fi):
+        sys.stderr.write("\rread {} of {} {}".format(nf,fi.size,sp.sum([ len(deltas[p]) for p in list(deltas.keys())])))
         h = fitsio.FITS(f)
         z = h['METADATA']['Z'][:]
         ll = sp.log10(h['WAVELENGTH'].read())
@@ -256,7 +257,8 @@ def desi_convert_transmission_to_delta_files(indir,outdir,lObs_min=3600.,lObs_ma
     T_stack[w] /= n_stack[w]
 
     ### Transform transmission to delta and store it
-    for p in sorted(list(deltas.keys())):
+    for nf, p in enumerate(sorted(list(deltas.keys()))):
+        sys.stderr.write("\rwrite {} of {} ".format(nf,len(list(deltas.keys()))))
         out = fitsio.FITS(outdir+'/delta-{}'.format(p)+'.fits.gz','rw',clobber=True)
         for d in deltas[p]:
             bins = sp.floor((d.ll-lmin)/dll+0.5).astype(int)

--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -172,7 +172,7 @@ def desi_from_ztarget_to_drq(ztarget,drq,spectype="QSO"):
     out.close()
 
     return
-def desi_convert_transmission_to_delta_files(indir,outdir,lOb_min=3600.,lObs_max=5500.,lRF_min=1040.,lRF_max=1200.,nspec=None):
+def desi_convert_transmission_to_delta_files(indir,outdir,lObs_min=3600.,lObs_max=5500.,lRF_min=1040.,lRF_max=1200.,nspec=None):
     '''
     Convert desi transmission files to picca delta files
     indir: path to transmission files directory

--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -172,13 +172,13 @@ def desi_from_ztarget_to_drq(ztarget,drq,spectype="QSO"):
     out.close()
 
     return
-def desi_convert_transmission_to_delta_files(indir,outdir,lObsrange=[3600.,5500.],lRFrange=[1040.,1200.],nspec=None):
+def desi_convert_transmission_to_delta_files(indir,outdir,lOb_min=3600.,lObs_max=5500.,lRF_min=1040.,lRF_max=1200.,nspec=None):
     '''
     Convert desi transmission files to picca delta files
     indir: path to transmission files directory
     outdir: path to write delta files directory
-    lObsrange = [3600.,5500.]: observed wavelength range in Angstrom
-    lRFrange = [1040.,1200.]: Rest frame wavelength range in Angstrom
+    lObs_min, lObs_max = [3600.,5500.]: observed wavelength range in Angstrom
+    lRF_min, lRF_max = [1040.,1200.]: Rest frame wavelength range in Angstrom
     '''
 
     ### List of transmission files
@@ -195,8 +195,6 @@ def desi_convert_transmission_to_delta_files(indir,outdir,lObsrange=[3600.,5500.
     deltas = {}
 
     ### Stack the transmission
-    lObs_min = lObsrange[0]
-    lObs_max = lObsrange[1]
     lObs_stack = sp.arange(lObs_min,lObs_max,1.)
     T_stack = sp.zeros(lObs_stack.size)
     n_stack = sp.zeros(lObs_stack.size)
@@ -216,7 +214,7 @@ def desi_convert_transmission_to_delta_files(indir,outdir,lObsrange=[3600.,5500.
         lObs = (10**ll)*sp.ones(nObj)[:,None]
         lRF = (10**ll)/(1.+z[:,None])
         w = sp.zeros_like(trans).astype(int)
-        w[ (lObs>lObsrange[0]) & (lObs<lObsrange[1]) & (lRF>lRFrange[0]) & (lRF<lRFrange[1]) ] = 1
+        w[ (lObs>lObs_min) & (lObs<lObs_max) & (lRF>lRF_min) & (lRF<lRF_max) ] = 1
         nbPixel = sp.sum(w,axis=1)
         cut = nbPixel>50
 

--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -177,8 +177,8 @@ def desi_convert_transmission_to_delta_files(indir,outdir,lObs_min=3600.,lObs_ma
     Convert desi transmission files to picca delta files
     indir: path to transmission files directory
     outdir: path to write delta files directory
-    lObs_min, lObs_max = [3600.,5500.]: observed wavelength range in Angstrom
-    lRF_min, lRF_max = [1040.,1200.]: Rest frame wavelength range in Angstrom
+    lObs_min, lObs_max = 3600.,5500.: observed wavelength range in Angstrom
+    lRF_min, lRF_max = 1040.,1200.: Rest frame wavelength range in Angstrom
     '''
 
     ### List of transmission files
@@ -190,14 +190,12 @@ def desi_convert_transmission_to_delta_files(indir,outdir,lObs_min=3600.,lObs_ma
         fi = glob.glob(indir+'/*.fits') + glob.glob(indir+'/*.fits.gz')
     fi = sorted(sp.array(fi))
 
-    ###
-    ndeltas = 0
-    deltas = {}
-
     ### Stack the transmission
     lObs_stack = sp.arange(lObs_min,lObs_max,1.)
     T_stack = sp.zeros(lObs_stack.size)
     n_stack = sp.zeros(lObs_stack.size)
+
+    deltas = {}
 
     ### Read
     for f in fi:
@@ -237,8 +235,7 @@ def desi_convert_transmission_to_delta_files(indir,outdir,lObs_min=3600.,lObs_ma
             tivar = sp.ones(tll.size)
             ttrans = trans[i,:][w[i,:]>0]
             deltas[pixnum].append(delta(thid[i],ra[i],dec[i],z[i],thid[i],thid[i],thid[i],tll,tivar,None,ttrans,1,None,None,None,None,None,None))
-            ndeltas += 1
-        if not nspec is None and ndeltas>nspec: break
+        if not nspec is None and sp.sum([ len(deltas[p]) for p in list(deltas.keys())])>=nspec: break
 
     ### Get stacked transmission
     w = n_stack>0.


### PR DESCRIPTION
Convert transmission files to delta files, simply run the following commands.
Maybe we should add ressampling, so that the correlations computation is not that long.
```
import picca.utils
indir = '/project/projectdirs/desi/mocks/lya_forest/london/v1.1/*/*/transmission-16-*.fits'
outdir = '/global/cscratch1/sd/hdumasde/igmhub/picca/CoLoRe_mocks/v2.1.1/Test_convert_transmission/'
picca.utils.desi_convert_transmission_to_delta_files(indir=indir,outdir=outdir,nspec=10000)
```