### PR TITLE
get only transmission files in zcat

### DIFF
--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -218,10 +218,13 @@ def desi_convert_transmission_to_delta_files(zcat,indir,outdir,lObs_min=3600.,lO
     for nf, f in enumerate(fi):
         sys.stderr.write("\rread {} of {} {}".format(nf,fi.size,sp.sum([ len(deltas[p]) for p in list(deltas.keys())])))
         h = fitsio.FITS(f)
+        thid = h['METADATA']['MOCKID'][:]
+        if sp.in1d(thid,zcat_thid).sum()==0:
+            h.close()
+            continue
         ra = h['METADATA']['RA'][:]*sp.pi/180.
         dec = h['METADATA']['DEC'][:]*sp.pi/180.
         z = h['METADATA']['Z'][:]
-        thid = h['METADATA']['MOCKID'][:]
         ll = sp.log10(h['WAVELENGTH'].read())
         trans = h['TRANSMISSION'].read()
         nObj = z.size

--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -194,7 +194,6 @@ def desi_convert_transmission_to_delta_files(zcat,indir,outdir,lObs_min=3600.,lO
     ### Catalog of objects
     h = fitsio.FITS(zcat)
     zcat_thid = h[1]['TARGETID'][:]
-    zcat_zqso = h[1]['Z'][:]
     h.close()
 
     ### List of transmission files

--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -221,17 +221,17 @@ def desi_convert_transmission_to_delta_files(zcat,indir,outdir,lObs_min=3600.,lO
     for nf, f in enumerate(fi):
         sys.stderr.write("\rread {} of {} {}".format(nf,fi.size,sp.sum([ len(deltas[p]) for p in list(deltas.keys())])))
         h = fitsio.FITS(f)
-        thid = h['METADATA']['MOCKID'][:]
+        thid = h[1]['MOCKID'][:]
         if sp.in1d(thid,zcat_thid).sum()==0:
             h.close()
             continue
-        ra = h['METADATA']['RA'][:]*sp.pi/180.
-        dec = h['METADATA']['DEC'][:]*sp.pi/180.
-        z = h['METADATA']['Z'][:]
-        ll = sp.log10(h['WAVELENGTH'].read())
-        trans = h['TRANSMISSION'].read()
+        ra = h[1]['RA'][:]*sp.pi/180.
+        dec = h[1]['DEC'][:]*sp.pi/180.
+        z = h[1]['Z'][:]
+        ll = sp.log10(h[2].read())
+        trans = h[3].read()
         nObj = z.size
-        pixnum = h['METADATA'].read_header()['PIXNUM']
+        pixnum = h[1].read_header()['PIXNUM']
 
         if trans.shape[0]!=nObj:
             trans = trans.transpose()

--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -194,6 +194,9 @@ def desi_convert_transmission_to_delta_files(zcat,indir,outdir,lObs_min=3600.,lO
     ### Catalog of objects
     h = fitsio.FITS(zcat)
     zcat_thid = h[1]['TARGETID'][:]
+    w = h[1]['Z'][:]>max(0.,lObs_min/lRF_max -1.)
+    w &= h[1]['Z'][:]<max(0.,lObs_max/lRF_min -1.)
+    zcat_thid = zcat_thid[w]
     h.close()
 
     ### List of transmission files

--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -231,7 +231,7 @@ def desi_convert_transmission_to_delta_files(zcat,indir,outdir,lObs_min=3600.,lO
         ll = sp.log10(h[2].read())
         trans = h[3].read()
         nObj = z.size
-        pixnum = h[1].read_header()['PIXNUM']
+        pixnum = f.split('-')[-1].split('.')[0]
 
         if trans.shape[0]!=nObj:
             trans = trans.transpose()


### PR DESCRIPTION
get only transmission files in zcat, send with something like this:
```
import picca.utils
zcat = '/project/projectdirs/desi/mocks/lya_forest/london/v1.1/quick-0.0/zcat.fits'
indir = '/project/projectdirs/desi/mocks/lya_forest/london/v1.1/*/*/transmission-16-*.fits'
outdir = '/global/cscratch1/sd/hdumasde/igmhub/picca/CoLoRe_mocks/v2.1.1/Test_convert_transmission_2/'
picca.utils.desi_convert_transmission_to_delta_files(zcat=zcat,indir=indir,outdir=outdir,nspec=10000)
```