### PR TITLE
Rescale covariance in fast MC

### DIFF
--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -31,6 +31,8 @@ class chi2:
             else:
                 self.seedfast_mc = 0
             self.nfast_mc = dic_init['fast mc']['niterations']
+            if 'covscaling' in dic_init['fast mc']:
+                self.scalefast_mc = dic_init['fast mc']['covscaling']
 
         if 'minos' in dic_init:
             self.minos_para = dic_init['minos']
@@ -184,8 +186,13 @@ class chi2:
         if not hasattr(self,"nfast_mc"): return
 
         sp.random.seed(self.seedfast_mc)
-
         nfast_mc = self.nfast_mc
+
+        if hasattr(self,"scalefast_mc"):
+            for d, s in zip(self.data, self.scalefast_mc):
+                d.co = s*d.co
+                d.ico = d.ico/s
+
         for d in self.data:
             d.cho = cholesky(d.co)
 
@@ -271,6 +278,8 @@ class chi2:
             g = f.create_group("fast mc")
             g.attrs['niterations'] = self.nfast_mc
             g.attrs['seed'] = self.seedfast_mc
+            if hasattr(self, "scalefast_mc"):
+                g.attrs['covscaling'] = self.scalefast_mc
             for p in self.fast_mc:
                 vals = sp.array(self.fast_mc[p])
                 d = g.create_dataset("{}/values".format(p), vals[:,0].shape, dtype="f")

--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -33,6 +33,8 @@ class chi2:
             self.nfast_mc = dic_init['fast mc']['niterations']
             if 'covscaling' in dic_init['fast mc']:
                 self.scalefast_mc = dic_init['fast mc']['covscaling']
+            else:
+                self.scalefast_mc = sp.ones(len(self.data))
 
         if 'minos' in dic_init:
             self.minos_para = dic_init['minos']
@@ -188,12 +190,9 @@ class chi2:
         sp.random.seed(self.seedfast_mc)
         nfast_mc = self.nfast_mc
 
-        if hasattr(self,"scalefast_mc"):
-            for d, s in zip(self.data, self.scalefast_mc):
-                d.co = s*d.co
-                d.ico = d.ico/s
-
-        for d in self.data:
+        for d, s in zip(self.data, self.scalefast_mc):
+            d.co = s*d.co
+            d.ico = d.ico/s
             d.cho = cholesky(d.co)
 
         self.fast_mc = {}
@@ -280,8 +279,7 @@ class chi2:
             g = f.create_group("fast mc")
             g.attrs['niterations'] = self.nfast_mc
             g.attrs['seed'] = self.seedfast_mc
-            if hasattr(self, "scalefast_mc"):
-                g.attrs['covscaling'] = self.scalefast_mc
+            g.attrs['covscaling'] = self.scalefast_mc
             for p in self.fast_mc:
                 vals = sp.array(self.fast_mc[p])
                 if p == 'chi2':

--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -197,6 +197,7 @@ class chi2:
             d.cho = cholesky(d.co)
 
         self.fast_mc = {}
+        self.fast_mc['chi2'] = []
         self.fast_mc_data = {}
         for it in range(nfast_mc):
             for d in self.data:
@@ -210,6 +211,7 @@ class chi2:
                 if not p in self.fast_mc:
                     self.fast_mc[p] = []
                 self.fast_mc[p].append([v, best_fit.errors[p]])
+            self.fast_mc['chi2'].append(best_fit.fval)
 
     def minos(self):
         if not hasattr(self,"minos_para"): return
@@ -282,10 +284,14 @@ class chi2:
                 g.attrs['covscaling'] = self.scalefast_mc
             for p in self.fast_mc:
                 vals = sp.array(self.fast_mc[p])
-                d = g.create_dataset("{}/values".format(p), vals[:,0].shape, dtype="f")
-                d[...] = vals[:,0]
-                d = g.create_dataset("{}/errors".format(p), vals[:,1].shape, dtype="f")
-                d[...] = vals[:,1]
+                if p == 'chi2':
+                    d = g.create_dataset("{}".format(p), vals.shape, dtype="f")
+                    d[...] = vals
+                else:
+                    d = g.create_dataset("{}/values".format(p), vals[:,0].shape, dtype="f")
+                    d[...] = vals[:,0]
+                    d = g.create_dataset("{}/errors".format(p), vals[:,1].shape, dtype="f")
+                    d[...] = vals[:,1]
             for p in self.fast_mc_data:
                 xi = self.fast_mc_data[p]
                 d = g.create_dataset(p, xi.shape, dtype="f")

--- a/py/picca/fitter2/parser.py
+++ b/py/picca/fitter2/parser.py
@@ -59,7 +59,8 @@ def parse_chi2(filename):
             if item=='covscaling':
                 value = value.split()
                 dic_init['fast mc'][item] = sp.array(value).astype(float)
-                assert len(dic_init['fast mc'][item])==len(dic_init['data sets']['data'])
+                if not len(dic_init['fast mc'][item])==len(dic_init['data sets']['data']):
+                    raise AssertionError()
             else:
                 dic_init['fast mc'][item] = int(value)
 

--- a/py/picca/fitter2/parser.py
+++ b/py/picca/fitter2/parser.py
@@ -56,7 +56,12 @@ def parse_chi2(filename):
     if 'fast mc' in cp.sections():
         dic_init['fast mc'] = {}
         for item, value in cp.items('fast mc'):
-            dic_init['fast mc'][item] = int(value)
+            if item=='covscaling':
+                value = value.split()
+                dic_init['fast mc'][item] = sp.array(value).astype(float)
+                assert len(dic_init['fast mc'][item])==len(dic_init['data sets']['data'])
+            else:
+                dic_init['fast mc'][item] = int(value)
 
     if cp.has_section('minos'):
         dic_init['minos'] = {}


### PR DESCRIPTION
Adds the option to rescale the covariance matrix inside fast MC for fitter2. Useful for making simple parameter projections. Set the optional scale factor in chi2.ini using e.g. (add more values for multi-fits)

[fast mc]
covscaling = 0.5

The PR also saves the chi2 of every fast MC fit.