### PR TITLE
Option to modify fast MC fiducial model

### DIFF
--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -35,6 +35,7 @@ class chi2:
                 self.scalefast_mc = dic_init['fast mc']['covscaling']
             else:
                 self.scalefast_mc = sp.ones(len(self.data))
+            self.fidfast_mc = dic_init['fast mc']['fiducial']
 
         if 'minos' in dic_init:
             self.minos_para = dic_init['minos']
@@ -195,13 +196,30 @@ class chi2:
             d.ico = d.ico/s
             d.cho = cholesky(d.co)
 
+        self.fiducial_values = self.best_fit.values.copy()
+        if len(self.fidfast_mc) != 0:
+            for p in self.fidfast_mc:
+                self.fiducial_values[p] = self.fidfast_mc[p]
+
+        self.fiducial_values['SB'] = False
+        for d in self.data:
+            d.fiducial_model = self.fiducial_values['bao_amp']*d.xi_model(self.k, self.pk_lin-self.pksb_lin, self.fiducial_values)
+
+            self.fiducial_values['SB'] = True
+            snl = self.fiducial_values['sigmaNL_per']
+            self.fiducial_values['sigmaNL_per'] = 0
+            d.fiducial_model += d.xi_model(self.k, self.pksb_lin, self.fiducial_values)
+            self.fiducial_values['SB'] = False
+            self.fiducial_values['sigmaNL_per'] = snl
+        del self.fiducial_values['SB']
+
         self.fast_mc = {}
         self.fast_mc['chi2'] = []
         self.fast_mc_data = {}
         for it in range(nfast_mc):
             for d in self.data:
                 g = sp.random.randn(len(d.da))
-                d.da = d.cho.dot(g) + d.best_fit_model
+                d.da = d.cho.dot(g) + d.fiducial_model
                 self.fast_mc_data[d.name+'_'+str(it)] = d.da
                 d.da_cut = d.da[d.mask]
 
@@ -280,6 +298,15 @@ class chi2:
             g.attrs['niterations'] = self.nfast_mc
             g.attrs['seed'] = self.seedfast_mc
             g.attrs['covscaling'] = self.scalefast_mc
+            if len(self.fidfast_mc) != 0:
+                fid = []
+                for p in self.fidfast_mc:
+                    g.attrs["fiducial[{}]".format(p)] = self.fidfast_mc[p]
+                    fid.append(p.encode('utf8'))
+                g.attrs['list of fiducial pars'] = fid
+                for d in self.data:
+                    fiducial = g.create_dataset("{}_fiducial".format(d.name), d.da.shape, dtype = "f")
+                    fiducial[...] = d.fiducial_model
             for p in self.fast_mc:
                 vals = sp.array(self.fast_mc[p])
                 if p == 'chi2':

--- a/py/picca/fitter2/parser.py
+++ b/py/picca/fitter2/parser.py
@@ -55,14 +55,17 @@ def parse_chi2(filename):
 
     if 'fast mc' in cp.sections():
         dic_init['fast mc'] = {}
+        dic_init['fast mc']['fiducial'] = {}
         for item, value in cp.items('fast mc'):
-            if item=='covscaling':
+            if item=='niterations' or item=='seed':
+                dic_init['fast mc'][item] = int(value)
+            elif item=='covscaling':
                 value = value.split()
                 dic_init['fast mc'][item] = sp.array(value).astype(float)
                 if not len(dic_init['fast mc'][item])==len(dic_init['data sets']['data']):
                     raise AssertionError()
             else:
-                dic_init['fast mc'][item] = int(value)
+                dic_init['fast mc']['fiducial'][item] = float(value)
 
     if cp.has_section('minos'):
         dic_init['minos'] = {}


### PR DESCRIPTION
This PR adds the option to modify the fast MC fiducial model by specifying parameter values in chi2.ini, e.g.

[fast mc]
ap = 1.0
at = 1.0

Parameters not specified are taken from the best fit, as before. The specified fiducial parameter values are saved in the output file (if any; similar to priors). The fiducial model is also saved.