### PR TITLE
returning the unsmooth covriance when there are empty bins

### DIFF
--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -31,8 +31,8 @@ def smooth_cov(da,we,rp,rt,drt=4,drp=4):
     nda = da.shape[1]
     var = sp.diagonal(co)
     if sp.any(var==0.):
-        print('ERROR: data has some empty bins, impossible to smooth')
-        print('ERROR: returning the unsmoothed covariance')
+        print('WARNING: data has some empty bins, impossible to smooth')
+        print('WARNING: returning the unsmoothed covariance')
         return co
 
     cor = co/sp.sqrt(var*var[:,None])

--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -32,7 +32,8 @@ def smooth_cov(da,we,rp,rt,drt=4,drp=4):
     var = sp.diagonal(co)
     if sp.any(var==0.):
         print('ERROR: data has some empty bins, impossible to smooth')
-        sys.exit()
+        print('ERROR: returning the unsmoothed covariance')
+        return co
 
     cor = co/sp.sqrt(var*var[:,None])
 


### PR DESCRIPTION
This PR include a minor change in the behavior of `export.py` when empty bins are present.