### PR TITLE
Option to mask absorbers in spectra

### DIFF
--- a/bin/do_deltas.py
+++ b/bin/do_deltas.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
         help='Absorber catalog file')
 
     parser.add_argument('--absorber-mask',type=float,default=2.5,required=False,
-        help='Number of spectral pixels to mask on each side of the absorber central observed wavelength')
+        help='Mask width on each side of the absorber central observed wavelength in units of 1e4*dlog10(lambda)')
 
     parser.add_argument('--mask-file',type=str,default=None,required=False,
         help='Path to file to mask regions in lambda_OBS and lambda_RF. In file each line is: region_name region_min region_max (OBS or RF) [Angstrom]')

--- a/bin/do_deltas.py
+++ b/bin/do_deltas.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
         help='Absorber catalog file')
 
     parser.add_argument('--absorber-mask',type=float,default=2.5,required=False,
-        help='Number of spectral pixels to mask on either side of the absorber central observed wavelength')
+        help='Number of spectral pixels to mask on each side of the absorber central observed wavelength')
 
     parser.add_argument('--mask-file',type=str,default=None,required=False,
         help='Path to file to mask regions in lambda_OBS and lambda_RF. In file each line is: region_name region_min region_max (OBS or RF) [Angstrom]')
@@ -239,7 +239,7 @@ if __name__ == '__main__':
 
     ### Veto absorbers
     if not args.absorber_vac is None:
-        print("removing absorbers")
+        print("adding absorbers")
         absorbers = io.read_absorbers(args.absorber_vac)
         nb_absorbers_in_forest = 0
         for p in data:

--- a/bin/do_deltas.py
+++ b/bin/do_deltas.py
@@ -82,6 +82,12 @@ if __name__ == '__main__':
     parser.add_argument('--dla-mask',type=float,default=0.8,required=False,
         help='Lower limit on the DLA transmission. Transmissions below this number are masked')
 
+    parser.add_argument('--absorber-vac',type=str,default=None,required=False,
+        help='Absorber catalog file')
+
+    parser.add_argument('--absorber-mask',type=float,default=2.5,required=False,
+        help='Number of spectral pixels to mask on either side of the absorber central observed wavelength')
+
     parser.add_argument('--mask-file',type=str,default=None,required=False,
         help='Path to file to mask regions in lambda_OBS and lambda_RF. In file each line is: region_name region_min region_max (OBS or RF) [Angstrom]')
 
@@ -137,6 +143,7 @@ if __name__ == '__main__':
     forest.dll = args.rebin*1e-4
     ## minumum dla transmission
     forest.dla_mask = args.dla_mask
+    forest.absorber_mask = args.absorber_mask
 
     ### Find the redshift range
     if (args.zqso_min is None):
@@ -229,6 +236,19 @@ if __name__ == '__main__':
             for p in data:
                 for d in data[p]:
                     d.mask(mask_obs=usr_mask_obs , mask_RF=usr_mask_RF)
+
+    ### Veto absorbers
+    if not args.absorber_vac is None:
+        print("removing absorbers")
+        absorbers = io.read_absorbers(args.absorber_vac)
+        nb_absorbers_in_forest = 0
+        for p in data:
+            for d in data[p]:
+                if d.thid in absorbers:
+                    for lambda_absorber in absorbers[d.thid]:
+                        d.add_absorber(lambda_absorber)
+                        nb_absorbers_in_forest += 1
+        log.write("Found {} absorbers in forests\n".format(nb_absorbers_in_forest))
 
     ### Correct for DLAs
     if not args.dla_vac is None:

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -82,6 +82,9 @@ class forest(qso):
     ### Correction function for multiplicative errors in inverse pipeline variance calibration
     correc_ivar = None
 
+    ## absorber pixel mask limit
+    absorber_mask = None
+
     ## minumum dla transmission
     dla_mask = None
 
@@ -232,6 +235,19 @@ class forest(qso):
             self.diff = self.diff[w]
             self.reso = self.reso[w]
 
+    def add_absorber(self,lambda_absorber):
+        if not hasattr(self,'ll'):
+            return
+
+        w = sp.ones(self.ll.size).astype(bool)
+        w = w & (sp.fabs(1e4*(self.ll-sp.log10(lambda_absorber)))>forest.absorber_mask)
+
+        self.iv = self.iv[w]
+        self.ll = self.ll[w]
+        self.fl = self.fl[w]
+        if self.diff is not None :
+            self.diff = self.diff[w]
+            self.reso = self.reso[w]
 
     def cont_fit(self):
         lmax = forest.lmax_rest+sp.log10(1+self.zqso)

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -239,8 +239,8 @@ class forest(qso):
         if not hasattr(self,'ll'):
             return
 
-        w = sp.ones(self.ll.size).astype(bool)
-        w &= (sp.fabs(1e4*(self.ll-sp.log10(lambda_absorber)))>forest.absorber_mask)
+        w = sp.ones(self.ll.size, dtype=bool)
+        w &= sp.fabs(1.e4*(self.ll-sp.log10(lambda_absorber)))>forest.absorber_mask
 
         self.iv = self.iv[w]
         self.ll = self.ll[w]

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -240,7 +240,7 @@ class forest(qso):
             return
 
         w = sp.ones(self.ll.size).astype(bool)
-        w = w & (sp.fabs(1e4*(self.ll-sp.log10(lambda_absorber)))>forest.absorber_mask)
+        w &= (sp.fabs(1e4*(self.ll-sp.log10(lambda_absorber)))>forest.absorber_mask)
 
         self.iv = self.iv[w]
         self.ll = self.ll[w]

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -43,6 +43,34 @@ def read_dlas(fdla):
 
     return dlas
 
+def read_absorbers(file_absorbers):
+    f=open(file_absorbers)
+    absorbers={}
+    nb_absorbers = 0
+    col_names=None
+    for l in f:
+        l = l.split()
+        if len(l)==0:continue
+        if l[0][0]=="#":continue
+        if l[0]=="ThingID":
+            col_names = l
+            continue
+        if l[0][0]=="-":continue
+        thid = int(l[col_names.index("ThingID")])
+        if thid not in absorbers:
+            absorbers[thid]=[]
+        lambda_absorber = float(l[col_names.index("lambda")])
+        absorbers[thid].append(lambda_absorber)
+        nb_absorbers += 1
+    f.close()
+
+    print("")
+    print(" In catalog: {} absorbers".format(nb_absorbers) )
+    print(" In catalog: {} forests have absorbers".format(len(absorbers)) )
+    print("")
+
+    return absorbers
+
 def read_drq(drq,zmin,zmax,keep_bal,bi_max=None):
     vac = fitsio.FITS(drq)
 


### PR DESCRIPTION
This PR introduces to do_deltas the option to mask pixels around identified absorbers at the per-spectrum level. Reads an ascii catalog with columns "ThingID" and "lambda" (analogous to the DLA catalog). Input the number of spectral pixels to remove on each side of the central wavelength.