### PR TITLE
Fit for relativistic effects

### DIFF
--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -125,6 +125,10 @@ class data:
         if 'radiation effects' in dic_init['model']:
             self.xi_rad_model = partial(getattr(xi, dic_init['model']['radiation effects']), name=self.name)
 
+        self.xi_rel_model = None
+        if 'relativistic effects' in dic_init['model']:
+            self.xi_rel_model = partial(getattr(xi, dic_init['model']['relativistic effects']), name=self.name)
+
         self.dm_met = {}
         self.rp_met = {}
         self.rt_met = {}
@@ -240,6 +244,9 @@ class data:
 
         if self.xi_rad_model is not None and pars['SB']==True:
             xi += self.xi_rad_model(self.r, self.mu, self.tracer1, self.tracer2, **pars)
+
+        if self.xi_rel_model is not None:
+            xi += self.xi_rel_model(self.r, self.mu, k, pk_lin, self.tracer1, self.tracer2, **pars)
 
         xi = self.dm.dot(xi)
 

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -126,8 +126,12 @@ class data:
             self.xi_rad_model = partial(getattr(xi, dic_init['model']['radiation effects']), name=self.name)
 
         self.xi_rel_model = None
-        if 'relativistic effects' in dic_init['model']:
-            self.xi_rel_model = partial(getattr(xi, dic_init['model']['relativistic effects']), name=self.name)
+        if 'relativistic correction' in dic_init['model']:
+            self.xi_rel_model = partial(getattr(xi, dic_init['model']['relativistic correction']), name=self.name)
+
+        self.xi_asy_model = None
+        if 'standard asymmetry' in dic_init['model']:
+            self.xi_asy_model = partial(getattr(xi, dic_init['model']['standard asymmetry']), name=self.name)
 
         self.dm_met = {}
         self.rp_met = {}
@@ -247,6 +251,9 @@ class data:
 
         if self.xi_rel_model is not None:
             xi += self.xi_rel_model(self.r, self.mu, k, pk_lin, self.tracer1, self.tracer2, **pars)
+
+        if self.xi_asy_model is not None:
+            xi += self.xi_asy_model(self.r, self.mu, k, pk_lin, self.tracer1, self.tracer2, **pars)
 
         xi = self.dm.dot(xi)
 

--- a/py/picca/fitter2/utils.py
+++ b/py/picca/fitter2/utils.py
@@ -14,7 +14,6 @@ muk=muk[:,None]
 def sinc(x):
     return sp.sin(x)/x
 
-#def Pk2Mp(ar,k,pk,ell_max=None):
 def Pk2Mp(ar,k,pk,ell_vals,tform=None):
     """
     Implementation of FFTLog from A.J.S. Hamilton (2000)
@@ -32,10 +31,8 @@ def Pk2Mp(ar,k,pk,ell_vals,tform=None):
     s=sp.argsort(r)
     r=r[s]
 
-    #xi=sp.zeros([ell_max//2+1,len(ar)])
     xi=sp.zeros([len(ell_vals),len(ar)])
 
-    #for ell in range(0,ell_max+1,2):
     for ell in ell_vals:
         if tform=="rel":
             pk_ell=pk
@@ -46,9 +43,7 @@ def Pk2Mp(ar,k,pk,ell_vals,tform=None):
         else:
             pk_ell=sp.sum(dmuk*L(muk,ell)*pk,axis=0)*(2*ell+1)*(-1)**(ell//2)/2/sp.pi**2
             n=2.
-        #pk_ell=sp.sum(dmuk*L(muk,ell)*pk,axis=0)*(2*ell+1)*(-1)**(ell//2)
         mu=ell+0.5
-        #n=2.
         q=2-n-0.5
         x=q+2*sp.pi*1j*emm/l
         lg1=myGamma.LogGammaLanczos((mu+1+x)/2)
@@ -56,7 +51,6 @@ def Pk2Mp(ar,k,pk,ell_vals,tform=None):
 
         um=(k0*r0)**(-2*sp.pi*1j*emm/l)*2**x*sp.exp(lg1-lg2)
         um[0]=sp.real(um[0])
-        #an=fft.fft(pk_ell*k**n/2/sp.pi**2*sp.sqrt(sp.pi/2))
         an=fft.fft(pk_ell*k**n*sp.sqrt(sp.pi/2))
         an*=um
         xi_loc=fft.ifft(an)
@@ -69,9 +63,6 @@ def Pk2Mp(ar,k,pk,ell_vals,tform=None):
     return xi
 
 def Pk2Xi(ar,mur,k,pk,ell_max=None):
-    #xi=Pk2Mp(ar,k,pk,ell_max)
-    #for ell in range(0,ell_max+1,2):
-    #    xi[ell//2,:]*=L(mur,ell)
     ell_vals=[ell for ell in range(0,ell_max+1,2)]
     xi=Pk2Mp(ar,k,pk,ell_vals)
     for ell in ell_vals:
@@ -81,7 +72,7 @@ def Pk2Xi(ar,mur,k,pk,ell_max=None):
 def Pk2XiRel(ar,mur,k,pk,kwargs):
     ell_vals=[1,3]
     xi=Pk2Mp(ar,k,pk,ell_vals,tform="rel")
-    return xi[1//2,:]*L(mur,1)*kwargs["Arel1"] + xi[3//2,:]*L(mur,3)*kwargs["Arel3"]
+    return kwargs["Arel1"]*xi[1//2,:]*L(mur,1) + kwargs["Arel3"]*xi[3//2,:]*L(mur,3)
 
 def Pk2XiAsy(ar,mur,k,pk,kwargs):
     ell_vals=[0,2]

--- a/py/picca/fitter2/utils.py
+++ b/py/picca/fitter2/utils.py
@@ -70,11 +70,37 @@ def Pk2Xi(ar,mur,k,pk,ell_max=None):
     return sp.sum(xi,axis=0)
 
 def Pk2XiRel(ar,mur,k,pk,kwargs):
+    """Calculate the cross-correlation contribution from relativistic effects (Bonvin et al. 2014).
+
+    Args:
+        ar (float): r coordinates
+        mur (float): mu coordinates
+        k (float): wavenumbers
+        pk (float): linear matter power spectrum
+        kwargs: dictionary of fit parameters
+
+    Returns:
+        sum of dipole and octupole correlation terms (float)
+
+    """
     ell_vals=[1,3]
     xi=Pk2Mp(ar,k,pk,ell_vals,tform="rel")
     return kwargs["Arel1"]*xi[1//2,:]*L(mur,1) + kwargs["Arel3"]*xi[3//2,:]*L(mur,3)
 
 def Pk2XiAsy(ar,mur,k,pk,kwargs):
+    """Calculate the cross-correlation contribution from standard asymmetry (Bonvin et al. 2014).
+
+    Args:
+        ar (float): r coordinates
+        mur (float): mu coordinates
+        k (float): wavenumbers
+        pk (float): linear matter power spectrum
+        kwargs: dictionary of fit parameters
+
+    Returns:
+        sum of dipole and octupole correlation terms (float)
+
+    """
     ell_vals=[0,2]
     xi=Pk2Mp(ar,k,pk,ell_vals,tform="asy")
     return (kwargs["Aasy0"]*xi[0//2,:] - kwargs["Aasy2"]*xi[2//2,:])*ar*L(mur,1) + kwargs["Aasy3"]*xi[2//2,:]*ar*L(mur,3)

--- a/py/picca/fitter2/xi.py
+++ b/py/picca/fitter2/xi.py
@@ -114,6 +114,21 @@ def xi_qso_radiation(r, mu, tracer1, tracer2, **pars):
 
     return xi_rad
 
+### Relativistic effects
+def xi_relativistic(r, mu, k, pk_lin, tracer1, tracer2, **pars):
+    assert (tracer1['type']=="continuous" or tracer2['type']=="continuous") and (tracer1['type']!=tracer2['type'])
+
+    ap, at = utils.cosmo_fit_func(pars)
+    rp = r*mu + pars["drp"]
+    rt = r*sp.sqrt(1-mu**2)
+    arp = ap*rp
+    art = at*rt
+    ar = sp.sqrt(arp**2+art**2)
+    amu = arp/ar
+
+    xi_rel = utils.Pk2XiRel(ar, amu, k, pk_lin, pars)
+    return xi_rel
+
 ### Growth factor evolution
 def growth_factor_no_de(z, zref=None, **kwargs):
     return (1+zref)/(1.+z)

--- a/py/picca/fitter2/xi.py
+++ b/py/picca/fitter2/xi.py
@@ -114,7 +114,7 @@ def xi_qso_radiation(r, mu, tracer1, tracer2, **pars):
 
     return xi_rad
 
-### Relativistic effects
+### Relativistic correction
 def xi_relativistic(r, mu, k, pk_lin, tracer1, tracer2, **pars):
     assert (tracer1['type']=="continuous" or tracer2['type']=="continuous") and (tracer1['type']!=tracer2['type'])
 
@@ -128,6 +128,21 @@ def xi_relativistic(r, mu, k, pk_lin, tracer1, tracer2, **pars):
 
     xi_rel = utils.Pk2XiRel(ar, amu, k, pk_lin, pars)
     return xi_rel
+
+### Standard asymmetry
+def xi_asymmetry(r, mu, k, pk_lin, tracer1, tracer2, **pars):
+    assert (tracer1['type']=="continuous" or tracer2['type']=="continuous") and (tracer1['type']!=tracer2['type'])
+
+    ap, at = utils.cosmo_fit_func(pars)
+    rp = r*mu + pars["drp"]
+    rt = r*sp.sqrt(1-mu**2)
+    arp = ap*rp
+    art = at*rt
+    ar = sp.sqrt(arp**2+art**2)
+    amu = arp/ar
+
+    xi_asy = utils.Pk2XiAsy(ar, amu, k, pk_lin, pars)
+    return xi_asy
 
 ### Growth factor evolution
 def growth_factor_no_de(z, zref=None, **kwargs):

--- a/py/picca/fitter2/xi.py
+++ b/py/picca/fitter2/xi.py
@@ -114,8 +114,22 @@ def xi_qso_radiation(r, mu, tracer1, tracer2, **pars):
 
     return xi_rad
 
-### Relativistic correction
 def xi_relativistic(r, mu, k, pk_lin, tracer1, tracer2, **pars):
+    """Calculate the cross-correlation contribution from relativistic effects (Bonvin et al. 2014).
+
+    Args:
+        r (float): r coordinates
+        mu (float): mu coordinates
+        k (float): wavenumbers
+        pk_lin (float): linear matter power spectrum
+        tracer1: dictionary of tracer1
+        tracer2: dictionary of tracer2
+        pars: dictionary of fit parameters
+
+    Returns:
+        sum of dipole and octupole correlation terms (float)
+
+    """
     assert (tracer1['type']=="continuous" or tracer2['type']=="continuous") and (tracer1['type']!=tracer2['type'])
 
     ap, at = utils.cosmo_fit_func(pars)
@@ -129,8 +143,22 @@ def xi_relativistic(r, mu, k, pk_lin, tracer1, tracer2, **pars):
     xi_rel = utils.Pk2XiRel(ar, amu, k, pk_lin, pars)
     return xi_rel
 
-### Standard asymmetry
 def xi_asymmetry(r, mu, k, pk_lin, tracer1, tracer2, **pars):
+    """Calculate the cross-correlation contribution from standard asymmetry (Bonvin et al. 2014).
+
+    Args:
+        r (float): r coordinates
+        mu (float): mu coordinates
+        k (float): wavenumbers
+        pk_lin (float): linear matter power spectrum
+        tracer1: dictionary of tracer1
+        tracer2: dictionary of tracer2
+        pars: dictionary of fit parameters
+
+    Returns:
+        sum of dipole and octupole correlation terms (float)
+
+    """
     assert (tracer1['type']=="continuous" or tracer2['type']=="continuous") and (tracer1['type']!=tracer2['type'])
 
     ap, at = utils.cosmo_fit_func(pars)


### PR DESCRIPTION
This PR adds the option to fit for the amplitudes of the dipole and octupole contribution from relativistic effects in the object-forest cross-correlation. It is not yet ready for a full review. @ngbusca could you take a look at whether the FFTlog implementation seems OK?