### PR TITLE
Run hesse as option

### DIFF
--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -26,9 +26,9 @@ class chi2:
         if 'verbosity' in dic_init:
             self.verbosity = dic_init['verbosity']
 
-        self.hess = False
-        if 'hess' in dic_init:
-            self.hess = dic_init['hess']
+        self.hesse = False
+        if 'hesse' in dic_init:
+            self.hesse = dic_init['hesse']
 
         if 'fast mc' in dic_init:
             if 'seed' in dic_init['fast mc']:
@@ -99,8 +99,8 @@ class chi2:
 
     def minimize(self):
         self.best_fit = self._minimize()
-        if self.hess:
-            self.best_fit.hess()
+        if self.hesse:
+            self.best_fit.hesse()
 
         self.best_fit.values['SB'] = False
         for d in self.data:
@@ -113,9 +113,6 @@ class chi2:
             self.best_fit.values['SB'] = False
             self.best_fit.values['sigmaNL_per'] = snl
         del self.best_fit.values['SB']
-
-    def hess(self):
-        self.best_fit.hesse()
 
     def chi2scan(self):
         if not hasattr(self, "dic_chi2scan"): return

--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -21,9 +21,14 @@ class chi2:
         self.k = dic_init['fiducial']['k']
         self.pk_lin = dic_init['fiducial']['pk']
         self.pksb_lin = dic_init['fiducial']['pksb']
+
         self.verbosity = 1
         if 'verbosity' in dic_init:
             self.verbosity = dic_init['verbosity']
+
+        self.hess = False
+        if 'hess' in dic_init:
+            self.hess = dic_init['hess']
 
         if 'fast mc' in dic_init:
             if 'seed' in dic_init['fast mc']:
@@ -94,6 +99,8 @@ class chi2:
 
     def minimize(self):
         self.best_fit = self._minimize()
+        if self.hess:
+            self.best_fit.hess()
 
         self.best_fit.values['SB'] = False
         for d in self.data:
@@ -106,6 +113,9 @@ class chi2:
             self.best_fit.values['SB'] = False
             self.best_fit.values['sigmaNL_per'] = snl
         del self.best_fit.values['SB']
+
+    def hess(self):
+        self.best_fit.hesse()
 
     def chi2scan(self):
         if not hasattr(self, "dic_chi2scan"): return

--- a/py/picca/fitter2/parser.py
+++ b/py/picca/fitter2/parser.py
@@ -53,6 +53,9 @@ def parse_chi2(filename):
     if 'verbosity' in cp.sections():
         dic_init['verbosity'] = int(cp.get('verbosity','level'))
 
+    if 'hess' in cp.sections():
+        dic_init['hess'] = int(cp.get('verbosity','level'))==1
+
     if 'fast mc' in cp.sections():
         dic_init['fast mc'] = {}
         dic_init['fast mc']['fiducial'] = {}

--- a/py/picca/fitter2/parser.py
+++ b/py/picca/fitter2/parser.py
@@ -53,8 +53,8 @@ def parse_chi2(filename):
     if 'verbosity' in cp.sections():
         dic_init['verbosity'] = int(cp.get('verbosity','level'))
 
-    if 'hess' in cp.sections():
-        dic_init['hess'] = int(cp.get('verbosity','level'))==1
+    if 'hesse' in cp.sections():
+        dic_init['hesse'] = int(cp.get('hesse','level'))==1
 
     if 'fast mc' in cp.sections():
         dic_init['fast mc'] = {}


### PR DESCRIPTION
This PR adds the option to run hesse.
In MgII-correlations, I get basically the same best fits and best errors but not the same correlation coefficients if I start far or near the minimum.
This is fixed by running hesse at the end of calculation.

- no hesse, near minimum: `cor[drp, bias_MgII(2796)] 49.3324951424`
- no hesse, far from minimum: `cor[drp, bias_MgII(2796)] 56.2345843166`
- with hesse, near minimum: `cor[drp, bias_MgII(2796)] 56.5666886943`
- with hesse, far from minimum: `cor[drp, bias_MgII(2796)] 56.5175449217`
