### PR TITLE
add removing very bad ZWARN in reobservation

### DIFF
--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -510,8 +510,11 @@ def read_from_spplate(in_dir, thid, ra, dec, zqso, plate, mjd, fid, order, log=N
         mjd_spall = spAll[1]["MJD"][:]
         fid_spall = spAll[1]["FIBERID"][:]
         qual_spall = spAll[1]["PLATEQUALITY"][:]
+        zwarn_spall = spAll[1]["ZWARNING"][:]
 
         w = sp.in1d(thid_spall, thid) & (qual_spall == b"good")
+        for zwarnbit in [0,1,7,8,9]:
+            w &= (zwarn_spall&2**zwarnbit)==0
         print("INFO: # unique objs: ",len(thid))
         print("INFO: # spectra: ",w.sum())
         thid = thid_spall[w]

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -513,6 +513,9 @@ def read_from_spplate(in_dir, thid, ra, dec, zqso, plate, mjd, fid, order, log=N
         zwarn_spall = spAll[1]["ZWARNING"][:]
 
         w = sp.in1d(thid_spall, thid) & (qual_spall == b"good")
+        ## Removing spectra with the following ZWARNING bits set:
+        ## SKY, LITTLE_COVERAGE, UNPLUGGED, BAD_TARGET, NODATA
+        ## https://www.sdss.org/dr14/algorithms/bitmasks/#ZWARNING
         for zwarnbit in [0,1,7,8,9]:
             w &= (zwarn_spall&2**zwarnbit)==0
         print("INFO: # unique objs: ",len(thid))


### PR DESCRIPTION
Fix issue https://github.com/igmhub/picca/issues/483
by removing objects where the bits `2^[0,1,7,8,9]` of ZWARNING flag are set.
This allows remove SKY, LITTLE_COVERAGE, UNPLUGGED, BAD_TARGET and NODATA.
we go from 286,211 spectra to 285,123 spectra for Lya forests.