### PR TITLE
Add cut on objectxobject pair redshift

### DIFF
--- a/bin/do_co.py
+++ b/bin/do_co.py
@@ -46,6 +46,12 @@ if __name__ == '__main__':
     parser.add_argument('--nt', type=int, default=50, required=False,
         help='Number of r-transverse bins')
 
+    parser.add_argument('--z-cut-min', type=float, default=0., required=False,
+        help='Use only pairs of object x object with the mean redshift larger than z-cut-min')
+
+    parser.add_argument('--z-cut-max', type=float, default=10., required=False,
+        help='Use only pairs of object x object with the mean redshift lower than z-cut-max')
+
     parser.add_argument('--z-min-obj', type=float, default=None, required=False,
         help='Min redshift for object field')
 
@@ -82,6 +88,8 @@ if __name__ == '__main__':
     co.rp_max = args.rp_max
     co.rp_min = args.rp_min
     co.rt_max = args.rt_max
+    cf.z_cut_min = args.z_cut_min
+    cf.z_cut_max = args.z_cut_max
     co.np     = args.np
     co.nt     = args.nt
     co.nside  = args.nside

--- a/bin/do_co.py
+++ b/bin/do_co.py
@@ -88,8 +88,8 @@ if __name__ == '__main__':
     co.rp_max = args.rp_max
     co.rp_min = args.rp_min
     co.rt_max = args.rt_max
-    cf.z_cut_min = args.z_cut_min
-    cf.z_cut_max = args.z_cut_max
+    co.z_cut_min = args.z_cut_min
+    co.z_cut_max = args.z_cut_max
     co.np     = args.np
     co.nt     = args.nt
     co.nside  = args.nside

--- a/py/picca/co.py
+++ b/py/picca/co.py
@@ -29,7 +29,7 @@ def fill_neighs(pix):
             ang = o1^neighs
             w = ang<angmax
             neighs = sp.array(neighs)[w]
-            o1.neighs = sp.array([o2 for o2 in neighs if o2.ra > o1.ra])
+            o1.neighs = sp.array([o2 for o2 in neighs if o2.ra > o1.ra and (o2.zqso+o1.zqso)/2.>=z_cut_min and (o2.zqso+o1.zqso)/2.<z_cut_max])
 
 def fill_neighs_x_correlation(pix):
     for ipix in pix:
@@ -40,7 +40,7 @@ def fill_neighs_x_correlation(pix):
             ang = o1^neighs
             w = ang<angmax
             neighs = sp.array(neighs)[w]
-            o1.neighs = sp.array([o2 for o2 in neighs])
+            o1.neighs = sp.array([o2 for o2 in neighs if (o2.zqso+o1.zqso)/2.>=z_cut_min and (o2.zqso+o1.zqso)/2.<z_cut_max])
 
 def co(pix):
 


### PR DESCRIPTION
Add cut on objectxobject pair redshift.
This will allow to run the auto correlations of quasars on desi mocks in different redshift bin and see if the bias, beta and growth rate is correct.