### PR TITLE
including additive and/or multiplicative broadbands

### DIFF
--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -313,7 +313,8 @@ class chi2:
                 gbb = g.create_group("broadband")
                 for k,bbs in d.bb.items():
                     for bb in bbs:
-                        bband = gbb.create_dataset(bb.name, d.da.shape, dtype = "f")
+                        bband = gbb.create_dataset(bb.name, 
+                                d.da.shape, dtype = "f")
                         bband[...] = bb(d.r, d.mu, **self.best_fit.values)
         del self.best_fit.values['SB']
 

--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -309,6 +309,12 @@ class chi2:
             g.attrs['chi2'] = d.chi2(self.k, self.pk_lin, self.pksb_lin, self.best_fit.values)
             fit = g.create_dataset("fit", d.da.shape, dtype = "f")
             fit[...] = d.best_fit_model
+            if d.bb != None:
+                gbb = g.create_group("broadband")
+                for k,bbs in d.bb.items():
+                    for bb in bbs:
+                        bband = gbb.create_dataset(bb.name, d.da.shape, dtype = "f")
+                        bband[...] = bb(d.r, d.mu, **self.best_fit.values)
         del self.best_fit.values['SB']
 
         if hasattr(self, "fast_mc"):

--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -311,9 +311,9 @@ class chi2:
             fit[...] = d.best_fit_model
             if d.bb != None:
                 gbb = g.create_group("broadband")
-                for k,bbs in d.bb.items():
+                for bbs in d.bb.values():
                     for bb in bbs:
-                        bband = gbb.create_dataset(bb.name, 
+                        bband = gbb.create_dataset(bb.name,
                                 d.da.shape, dtype = "f")
                         bband[...] = bb(d.r, d.mu, **self.best_fit.values)
         del self.best_fit.values['SB']

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -143,8 +143,8 @@ class data:
                 deg_mu_max = dic_bb['deg_mu_max']
                 ddeg_mu = dic_bb['ddeg_mu']
     
-                name = 'BB-{}-{} {} {}'.format(self.name,
-                        ibb,dic_bb['type'],dic_bb['pre'])
+                name = 'BB-{}-{} {} {} {}'.format(self.name,
+                        ibb,dic_bb['type'],dic_bb['pre'],dic_bb['rp_rt'])
 
                 bb_pars = {'{} ({},{})'.format(name,i,j):0\
                     for i in range(deg_r_min,deg_r_max+1,ddeg_r)\
@@ -157,7 +157,7 @@ class data:
                 bb = partial(xi.broadband, deg_r_min=deg_r_min,
                     deg_r_max=deg_r_max, ddeg_r=ddeg_r,
                     deg_mu_min=deg_mu_min, deg_mu_max=deg_mu_max,
-                    ddeg_mu=ddeg_mu, 
+                    ddeg_mu=ddeg_mu,rp_rt = dic_bb['rp_rt']=='rp,rt',
                     name=name)
                 bb.name = name
 

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -94,11 +94,6 @@ class data:
         self.r = r
         self.mu = mu
 
-        self.par_names = dic_init['parameters']['values'].keys()
-        self.pars_init = dic_init['parameters']['values']
-        self.par_error = dic_init['parameters']['errors']
-        self.par_limit = dic_init['parameters']['limits']
-        self.par_fixed = dic_init['parameters']['fix']
 
         self.pk = pk.pk(getattr(pk, dic_init['model']['model-pk']))
         self.pk *= partial(getattr(pk,'G2'), dataset_name=self.name)
@@ -132,6 +127,48 @@ class data:
         self.xi_asy_model = None
         if 'standard asymmetry' in dic_init['model']:
             self.xi_asy_model = partial(getattr(xi, dic_init['model']['standard asymmetry']), name=self.name)
+
+        self.bb = {}
+        self.bb['pre-add'] = []
+        self.bb['pos-add'] = []
+        self.bb['pre-mul'] = []
+        self.bb['pos-mul'] = []
+        if 'broadband' in dic_init:
+            for ibb,dic_bb in enumerate(dic_init['broadband']):
+                deg_r_min = dic_bb['deg_r_min']
+                deg_r_max = dic_bb['deg_r_max']
+                ddeg_r = dic_bb['ddeg_r']
+
+                deg_mu_min = dic_bb['deg_mu_min']
+                deg_mu_max = dic_bb['deg_mu_max']
+                ddeg_mu = dic_bb['ddeg_mu']
+    
+                name = 'BB-{}-{} {} {}'.format(self.name,
+                        ibb,dic_bb['type'],dic_bb['pre'])
+
+                bb_pars = {'{} ({},{})'.format(name,i,j):0\
+                    for i in range(deg_r_min,deg_r_max+1,ddeg_r)\
+                        for j in range(deg_mu_min, deg_mu_max+1, ddeg_mu)}
+        
+                for k,v in bb_pars.items():
+                    dic_init['parameters']['values'][k]=v
+                    dic_init['parameters']['errors']['error_'+k]=0.01
+
+                bb = partial(xi.broadband, deg_r_min=deg_r_min,
+                    deg_r_max=deg_r_max, ddeg_r=ddeg_r,
+                    deg_mu_min=deg_mu_min, deg_mu_max=deg_mu_max,
+                    ddeg_mu=ddeg_mu, 
+                    name=name)
+                bb.name = name
+
+                pre = dic_bb['pre']
+                self.bb[dic_bb['pre']+"-"+dic_bb['type']].append(bb)
+
+        self.par_names = dic_init['parameters']['values'].keys()
+        self.pars_init = dic_init['parameters']['values']
+        self.par_error = dic_init['parameters']['errors']
+        self.par_limit = dic_init['parameters']['limits']
+        self.par_fixed = dic_init['parameters']['fix']
 
         self.dm_met = {}
         self.rp_met = {}
@@ -254,8 +291,24 @@ class data:
 
         if self.xi_asy_model is not None:
             xi += self.xi_asy_model(self.r, self.mu, k, pk_lin, self.tracer1, self.tracer2, **pars)
+ 
+        ## pre-distortion broadband 
+        for bb in self.bb['pre-mul']:
+            xi *= (1+ bb(self.r, self.mu,**pars))
+
+        ## pre-distortion additive
+        for bb in self.bb['pre-add']:
+            xi += bb(self.r, self.mu, **pars)
 
         xi = self.dm.dot(xi)
+
+        ## pos-distortion multiplicative
+        for bb in self.bb['pos-mul']:
+            xi *= (1+bb(self.r, self.mu, **pars))
+
+        ## pos-distortion additive
+        for bb in self.bb['pos-add']:
+            xi += bb(self.r, self.mu, **pars)
 
         return xi
 

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -149,7 +149,7 @@ class data:
                 bb_pars = {'{} ({},{})'.format(name,i,j):0\
                     for i in range(deg_r_min,deg_r_max+1,ddeg_r)\
                         for j in range(deg_mu_min, deg_mu_max+1, ddeg_mu)}
-        
+
                 dic_init['parameters']['values'] =\
                         {k:v for k,v in bb_pars.items()}
 

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -150,9 +150,11 @@ class data:
                     for i in range(deg_r_min,deg_r_max+1,ddeg_r)\
                         for j in range(deg_mu_min, deg_mu_max+1, ddeg_mu)}
         
-                for k,v in bb_pars.items():
-                    dic_init['parameters']['values'][k]=v
-                    dic_init['parameters']['errors']['error_'+k]=0.01
+                dic_init['parameters']['values'] =\
+                        {k:v for k,v in bb_pars.items()}
+
+                dic_init['parameters']['errors'] =\
+                        {'error_'+k:0.01 for k in bb_pars.keys()}
 
                 bb = partial(xi.broadband, deg_r_min=deg_r_min,
                     deg_r_max=deg_r_max, ddeg_r=ddeg_r,
@@ -161,7 +163,6 @@ class data:
                     name=name)
                 bb.name = name
 
-                pre = dic_bb['pre']
                 self.bb[dic_bb['pre']+"-"+dic_bb['type']].append(bb)
 
         self.par_names = dic_init['parameters']['values'].keys()
@@ -292,9 +293,9 @@ class data:
         if self.xi_asy_model is not None:
             xi += self.xi_asy_model(self.r, self.mu, k, pk_lin, self.tracer1, self.tracer2, **pars)
  
-        ## pre-distortion broadband 
+        ## pre-distortion broadband
         for bb in self.bb['pre-mul']:
-            xi *= (1+ bb(self.r, self.mu,**pars))
+            xi *= 1+ bb(self.r, self.mu,**pars)
 
         ## pre-distortion additive
         for bb in self.bb['pre-add']:
@@ -304,7 +305,7 @@ class data:
 
         ## pos-distortion multiplicative
         for bb in self.bb['pos-mul']:
-            xi *= (1+bb(self.r, self.mu, **pars))
+            xi *= 1+bb(self.r, self.mu, **pars)
 
         ## pos-distortion additive
         for bb in self.bb['pos-add']:

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -150,11 +150,9 @@ class data:
                     for i in range(deg_r_min,deg_r_max+1,ddeg_r)\
                         for j in range(deg_mu_min, deg_mu_max+1, ddeg_mu)}
 
-                dic_init['parameters']['values'] =\
-                        {k:v for k,v in bb_pars.items()}
-
-                dic_init['parameters']['errors'] =\
-                        {'error_'+k:0.01 for k in bb_pars.keys()}
+                for k,v in bb_pars.items():
+                   dic_init['parameters']['values'][k] = v
+                   dic_init['parameters']['errors']['error_'+k] = 0.01
 
                 bb = partial(xi.broadband, deg_r_min=deg_r_min,
                     deg_r_max=deg_r_max, ddeg_r=ddeg_r,

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -292,7 +292,7 @@ class data:
 
         if self.xi_asy_model is not None:
             xi += self.xi_asy_model(self.r, self.mu, k, pk_lin, self.tracer1, self.tracer2, **pars)
- 
+
         ## pre-distortion broadband
         for bb in self.bb['pre-mul']:
             xi *= 1+ bb(self.r, self.mu,**pars)

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -142,7 +142,7 @@ class data:
                 deg_mu_min = dic_bb['deg_mu_min']
                 deg_mu_max = dic_bb['deg_mu_max']
                 ddeg_mu = dic_bb['ddeg_mu']
-    
+
                 name = 'BB-{}-{} {} {} {}'.format(self.name,
                         ibb,dic_bb['type'],dic_bb['pre'],dic_bb['rp_rt'])
 

--- a/py/picca/fitter2/parser.py
+++ b/py/picca/fitter2/parser.py
@@ -157,7 +157,7 @@ def parse_data(filename,zeff,fiducial):
             dic_bb['pre'] = value[1]
 
             assert value[2]=='rp,rt' or value[2]=='r,mu'
-            dic_bb['rt_rp'] = value[2]=='rp,rt'
+            dic_bb['rp_rt'] = value[2]
 
             deg_r_min,deg_r_max,ddeg_r = value[3].split(':')
             dic_bb['deg_r_min'] = int(deg_r_min)

--- a/py/picca/fitter2/parser.py
+++ b/py/picca/fitter2/parser.py
@@ -123,6 +123,7 @@ def parse_data(filename,zeff,fiducial):
     dic_init['parameters']['errors'] = {}
     dic_init['parameters']['limits'] = {}
     dic_init['parameters']['fix'] = {}
+
     for item, value in cp.items('parameters'):
         value = value.split()
         dic_init['parameters']['values'][item] = float(value[0])
@@ -143,6 +144,31 @@ def parse_data(filename,zeff,fiducial):
             dic_init['metals']['in tracer1'] = dic_init['metals']['in tracer1'].split()
         if 'in tracer2' in dic_init['metals']:
             dic_init['metals']['in tracer2'] = dic_init['metals']['in tracer2'].split()
+
+    if 'broadband' in cp.sections():
+        dic_init['broadband'] = []
+        for item, value in cp.items('broadband'):
+            dic_bb = {}
+            value = value.split()
+            assert value[0] == 'add' or value[0] == 'mul'
+            dic_bb['type'] = value[0]
+
+            assert value[1] == 'pre' or value[1] == 'pos'
+            dic_bb['pre'] = value[1]
+
+            assert value[2]=='rp,rt' or value[2]=='r,mu'
+            dic_bb['rt_rp'] = value[2]=='rp,rt'
+
+            deg_r_min,deg_r_max,ddeg_r = value[3].split(':')
+            dic_bb['deg_r_min'] = int(deg_r_min)
+            dic_bb['deg_r_max'] = int(deg_r_max)
+            dic_bb['ddeg_r'] = int(ddeg_r)
+
+            deg_mu_min, deg_mu_max, ddeg_mu = value[4].split(':')
+            dic_bb['deg_mu_min'] = int(deg_mu_min)
+            dic_bb['deg_mu_max'] = int(deg_mu_max)
+            dic_bb['ddeg_mu'] = int(ddeg_mu)
+            dic_init['broadband'].append(dic_bb)
 
     if 'priors' in cp.sections():
         for item, value in cp.items('priors'):

--- a/py/picca/fitter2/xi.py
+++ b/py/picca/fitter2/xi.py
@@ -232,10 +232,10 @@ def qso_bias_vs_z_croom(z, tracer, zref = None, **kwargs):
     return (p0 + p1*(1.+z)**2)/(p0 + p1*(1+zref)**2)
 
 
-def broadband(r, mu, *pars, deg_r_min=None, deg_r_max=None, 
+def broadband(r, mu, deg_r_min=None, deg_r_max=None, 
         ddeg_r=None, deg_mu_min=None, deg_mu_max=None,
         ddeg_mu=None, deg_mu=None, name=None, 
-        rt_rp=False, **kwargs):
+        rt_rp=False, *pars, **kwargs):
     '''
     Broadband function interface.
     Calculates a power-law broadband in r and mu or rp,rt

--- a/py/picca/fitter2/xi.py
+++ b/py/picca/fitter2/xi.py
@@ -230,3 +230,44 @@ def qso_bias_vs_z_croom(z, tracer, zref = None, **kwargs):
     p0 = kwargs["croom_par0"]
     p1 = kwargs["croom_par1"]
     return (p0 + p1*(1.+z)**2)/(p0 + p1*(1+zref)**2)
+
+
+def broadband(r, mu, *pars, deg_r_min=None, deg_r_max=None, 
+        ddeg_r=None, deg_mu_min=None, deg_mu_max=None,
+        ddeg_mu=None, deg_mu=None, name=None, 
+        rt_rp=False, **kwargs):
+    '''
+    Broadband function interface.
+    Calculates a power-law broadband in r and mu or rp,rt
+    Arguments:
+        - r,mu: (array or float) where to calcualte the broadband
+        - deg_r_min: (int) degree of the lowest-degree monomial in r or rp
+        - deg_r_max: (int) degree of the highest-degree monomual in r or rp
+        - ddeg_r: (int) degree step in r or rp
+        - deg_mu_min: (int) degree of the lowest-degree monomial in mu or rt
+        - deg_mu_max: (int) degree of the highest-degree monmial in mu or rt
+        - ddeg_mu: (int) degree step in mu or rt
+        - name: (string) name ot identify the corresponding parameters,
+                    typically the dataset name and whether it's multiplicative
+                    of additive
+        - rt_rp: (bool) use r,mu (if False) or rp,rt (if True)
+        - *pars: additional parameters to be ignored
+        **kwargs: (dict) dictionary containing all the polynomial
+                    coefficients
+    '''
+    
+    bb = 0
+    r1 = r/100
+    r2 = mu
+    if rt_rp:
+        r1 = r*mu
+        r2 = r*sp.sqrt(1-mu**2)
+
+    r1_pows = sp.arange(deg_r_min, deg_r_max+1, ddeg_r)
+    r2_pows = sp.arange(deg_mu_min, deg_mu_max+1, ddeg_mu)
+    BB = [kwargs['{} ({},{})'.format(name,i,j)] for i in r1_pows
+            for j in r2_pows]
+    BB = sp.array(BB).reshape(-1,deg_r_max-deg_r_min+1)
+
+    return (BB[:,:,None,None]*r1**r1_pows[:,None,None]*\
+            r2**r2_pows[None,:,None]).sum(axis=(0,1,2))

--- a/py/picca/fitter2/xi.py
+++ b/py/picca/fitter2/xi.py
@@ -232,9 +232,9 @@ def qso_bias_vs_z_croom(z, tracer, zref = None, **kwargs):
     return (p0 + p1*(1.+z)**2)/(p0 + p1*(1+zref)**2)
 
 
-def broadband(r, mu, deg_r_min=None, deg_r_max=None, 
+def broadband(r, mu, deg_r_min=None, deg_r_max=None,
         ddeg_r=None, deg_mu_min=None, deg_mu_max=None,
-        ddeg_mu=None, deg_mu=None, name=None, 
+        ddeg_mu=None, deg_mu=None, name=None,
         rp_rt=False, *pars, **kwargs):
     '''
     Broadband function interface.
@@ -251,12 +251,11 @@ def broadband(r, mu, deg_r_min=None, deg_r_max=None,
                     typically the dataset name and whether it's multiplicative
                     of additive
         - rt_rp: (bool) use r,mu (if False) or rp,rt (if True)
-        - *pars: additional parameters to be ignored
+        - *pars: additional parameters that are ignored (for convenience)
         **kwargs: (dict) dictionary containing all the polynomial
-                    coefficients
+                    coefficients. Any extra keywords are ignored
     '''
-    
-    bb = 0
+
     r1 = r/100
     r2 = mu
     if rp_rt:

--- a/py/picca/fitter2/xi.py
+++ b/py/picca/fitter2/xi.py
@@ -235,7 +235,7 @@ def qso_bias_vs_z_croom(z, tracer, zref = None, **kwargs):
 def broadband(r, mu, deg_r_min=None, deg_r_max=None, 
         ddeg_r=None, deg_mu_min=None, deg_mu_max=None,
         ddeg_mu=None, deg_mu=None, name=None, 
-        rt_rp=False, *pars, **kwargs):
+        rp_rt=False, *pars, **kwargs):
     '''
     Broadband function interface.
     Calculates a power-law broadband in r and mu or rp,rt
@@ -259,9 +259,9 @@ def broadband(r, mu, deg_r_min=None, deg_r_max=None,
     bb = 0
     r1 = r/100
     r2 = mu
-    if rt_rp:
-        r1 = r*mu
-        r2 = r*sp.sqrt(1-mu**2)
+    if rp_rt:
+        r1 = (r/100)*mu
+        r2 = (r/100)*sp.sqrt(1-mu**2)
 
     r1_pows = sp.arange(deg_r_min, deg_r_max+1, ddeg_r)
     r2_pows = sp.arange(deg_mu_min, deg_mu_max+1, ddeg_mu)


### PR DESCRIPTION
This PR adds the possibility of including additive and/or multiplicative broadbands to the xi-model, both pre and post distortion and in r,mu or rp,rt

Example usage (add the following section to the individual .ini of the datasets):

    [broadband]
    bb1 = add pos r,mu 0:2:1 0:6:2

adds an `add`itive `pos`t-distortion broadband where monomials are proportional to `r^i mu^j` with `i=0,1,2` and `j=0,2,4,6`. The name `bb1` is arbitrary and ignored by the code (but required for the .ini format).

Other examples:

    ## multiplicative, pre-distortion, r^i*mu^j for i=0,1,2 and j = 0,1,2
    ## plus an additive post-distortion in rp^i*rt^j for i=0,1,2 and j=0,1,2
    ## the multiplicative broadband is implemented as xi_bb = (1+bb)*xi
    ## so adding constants to a multiplicative bb leads to degeneracies 
    ## (the user is expected to know what she is doing)
    bb2 = mul pre r,mu 0:2:1 0:2:1
    bb3 = add pos rp,rt 0:2:1 0:2:1

Broadbands are stored in the output file as the group `data-set-name/broadband/broadband-name` in the output `h5` file where  `broadband-name` is constructed as: `BB-data-set-name add|mul pre|pos `

There's no limit in the number of additive and multiplicative broadbands, the user is responsible for degeneracies. @londumas @vserret @mblomqvist can you test?


