### PR TITLE
Modified codd_zint to use id matrix as dmat if requested

### DIFF
--- a/bin/coadd_zint
+++ b/bin/coadd_zint
@@ -44,7 +44,7 @@ if not args.no_dmat:
     dm = h[1]['DM'][:]*0
     h.close()
 else:
-    dm = sp.zeros((nb.shape[0],nb.shape[0]))
+    dm = sp.eye(nb.shape[0])
 
 for f in args.data:
     if not (os.path.isfile(f.replace('cf','dmat')) or args.no_dmat):
@@ -73,8 +73,7 @@ for f in args.data:
         h = fitsio.FITS(f.replace('cf','dmat'))
         dm += h[1]['DM'][:]*wet_aux[:,None]
         h.close()
-    else:
-        dm += sp.identity(nb.shape[0])*wet_aux[:,None]
+
 for p in da:
     w=we[p]>0
     da[p][w]/=we[p][w]

--- a/bin/coadd_zint
+++ b/bin/coadd_zint
@@ -17,6 +17,8 @@ parser.add_argument("--data",type=str,nargs="*",required=True,
 parser.add_argument("--out",type=str,required=True,
         help="output file")
 
+parser.add_argument("--no-dmat",action='store_true',default=False,required=False,
+        help='Use an identity matrix as the distortion matrix.')
 
 args=parser.parse_args()
 
@@ -37,12 +39,15 @@ h.close()
 da = {}
 we = {}
 
-h = fitsio.FITS(args.data[0].replace('cf','dmat'))
-dm = h[1]['DM'][:]*0
-h.close()
+if not args.no_dmat:
+    h = fitsio.FITS(args.data[0].replace('cf','dmat'))
+    dm = h[1]['DM'][:]*0
+    h.close()
+else:
+    dm = sp.zeros((nb.shape[0],nb.shape[0]))
 
 for f in args.data:
-    if not os.path.isfile(f.replace('cf','dmat')):
+    if not (os.path.isfile(f.replace('cf','dmat')) or args.no_dmat):
         continue
     h = fitsio.FITS(f)
     we_aux = h[2]["WE"][:]
@@ -64,9 +69,12 @@ for f in args.data:
             we[p] = we_aux[i]
     h.close()
 
-    h = fitsio.FITS(f.replace('cf','dmat'))
-    dm += h[1]['DM'][:]*wet_aux[:,None]
-
+    if not args.no_dmat:
+        h = fitsio.FITS(f.replace('cf','dmat'))
+        dm += h[1]['DM'][:]*wet_aux[:,None]
+        h.close()
+    else:
+        dm += sp.identity(nb.shape[0])*wet_aux[:,None]
 for p in da:
     w=we[p]>0
     da[p][w]/=we[p][w]

--- a/bin/coadd_zint
+++ b/bin/coadd_zint
@@ -81,7 +81,8 @@ for p in da:
 rp /= wet
 rt /= wet
 z /= wet
-dm /= wet[:,None]
+if not args.no_dmat:
+    dm /= wet[:,None]
 
 da = sp.vstack(list(da.values()))
 we = sp.vstack(list(we.values()))


### PR DESCRIPTION
As discussed in the picca-users group email, this merge adds a `no-dmat` option to `bin/coadd_zint`, setting the distortion matrix to the identity instead of loading from file.

I am not sure wether the multiplication of the identity matrix by `wet_aux` in line 77 - `dm += sp.identity(nb.shape[0])*wet_aux[:,None]` - is necessary, but including it seemed closer to the standard procedure (line 74). 