### PR TITLE
Keep all pairs in delta delta correlations

### DIFF
--- a/bin/do_cf.py
+++ b/bin/do_cf.py
@@ -82,6 +82,9 @@ if __name__ == '__main__':
     parser.add_argument('--no-project', action='store_true', required=False,
         help='Do not project out continuum fitting modes')
 
+    parser.add_argument('--remove-same-half-plate-close-pairs', action='store_true', required=False,
+        help='Reject pairs in the first bin in r-parallel from same half plate')
+
     parser.add_argument('--nside', type=int, default=16, required=False,
         help='Healpix nside')
 
@@ -108,6 +111,7 @@ if __name__ == '__main__':
     cf.zref = args.z_ref
     cf.alpha = args.z_evol
     cf.lambda_abs = constants.absorber_IGM[args.lambda_abs]
+    cf.remove_same_half_plate_close_pairs = args.remove_same_half_plate_close_pairs
 
     cosmo = constants.cosmo(args.fid_Om)
 

--- a/bin/do_cf.py
+++ b/bin/do_cf.py
@@ -82,9 +82,6 @@ if __name__ == '__main__':
     parser.add_argument('--no-project', action='store_true', required=False,
         help='Do not project out continuum fitting modes')
 
-    parser.add_argument('--no-same-wavelength-pairs', action='store_true', required=False,
-        help='Reject pairs with same wavelength')
-
     parser.add_argument('--nside', type=int, default=16, required=False,
         help='Healpix nside')
 
@@ -110,7 +107,6 @@ if __name__ == '__main__':
     cf.nside = args.nside
     cf.zref = args.z_ref
     cf.alpha = args.z_evol
-    cf.no_same_wavelength_pairs = args.no_same_wavelength_pairs
     cf.lambda_abs = constants.absorber_IGM[args.lambda_abs]
 
     cosmo = constants.cosmo(args.fid_Om)

--- a/bin/do_cf_angl.py
+++ b/bin/do_cf_angl.py
@@ -78,9 +78,6 @@ if __name__ == '__main__':
     parser.add_argument('--no-project', action='store_true', required=False,
         help='Do not project out continuum fitting modes')
 
-    parser.add_argument('--no-same-wavelength-pairs', action='store_true', required=False,
-        help='Reject pairs with same wavelength')
-
     parser.add_argument('--nside', type=int, default=16, required=False,
         help='Healpix nside')
 
@@ -109,7 +106,6 @@ if __name__ == '__main__':
     cf.x_correlation   = False
     cf.ang_correlation = True
     cf.angmax          = args.ang_max
-    cf.no_same_wavelength_pairs = args.no_same_wavelength_pairs
     cf.lambda_abs = constants.absorber_IGM[args.lambda_abs]
 
 

--- a/bin/do_cf_angl.py
+++ b/bin/do_cf_angl.py
@@ -78,6 +78,9 @@ if __name__ == '__main__':
     parser.add_argument('--no-project', action='store_true', required=False,
         help='Do not project out continuum fitting modes')
 
+    parser.add_argument('--remove-same-half-plate-close-pairs', action='store_true', required=False,
+        help='Reject pairs in the first bin in r-parallel from same half plate')
+
     parser.add_argument('--nside', type=int, default=16, required=False,
         help='Healpix nside')
 
@@ -107,6 +110,7 @@ if __name__ == '__main__':
     cf.ang_correlation = True
     cf.angmax          = args.ang_max
     cf.lambda_abs = constants.absorber_IGM[args.lambda_abs]
+    cf.remove_same_half_plate_close_pairs = args.remove_same_half_plate_close_pairs
 
 
     ### Read data 1

--- a/bin/do_dmat.py
+++ b/bin/do_dmat.py
@@ -81,8 +81,8 @@ if __name__ == '__main__':
     parser.add_argument('--no-project', action='store_true', required=False,
         help='Do not project out continuum fitting modes')
 
-    parser.add_argument('--no-same-wavelength-pairs', action='store_true', required=False,
-        help='Reject pairs with same wavelength')
+    parser.add_argument('--remove-same-half-plate-close-pairs', action='store_true', required=False,
+        help='Reject pairs in the first bin in r-parallel from same half plate')
 
     parser.add_argument('--rej', type=float, default=1., required=False,
         help='Fraction of rejected forest-forest pairs: -1=no rejection, 1=all rejection')
@@ -115,8 +115,8 @@ if __name__ == '__main__':
     cf.zref = args.z_ref
     cf.alpha = args.z_evol
     cf.rej = args.rej
-    cf.no_same_wavelength_pairs = args.no_same_wavelength_pairs
     cf.lambda_abs = constants.absorber_IGM[args.lambda_abs]
+    cf.remove_same_half_plate_close_pairs = args.remove_same_half_plate_close_pairs
 
     cosmo = constants.cosmo(args.fid_Om)
 

--- a/bin/do_metal_dmat.py
+++ b/bin/do_metal_dmat.py
@@ -88,8 +88,8 @@ if __name__ == '__main__':
     parser.add_argument('--fid-Om', type=float, default=0.315, required=False,
         help='Omega_matter(z=0) of fiducial LambdaCDM cosmology')
 
-    parser.add_argument('--no-same-wavelength-pairs', action='store_true', required=False,
-        help='Reject pairs with same wavelength')
+    parser.add_argument('--remove-same-half-plate-close-pairs', action='store_true', required=False,
+        help='Reject pairs in the first bin in r-parallel from same half plate')
 
     parser.add_argument('--rej', type=float, default=1., required=False,
         help='Fraction of rejected forest-forest pairs: -1=no rejection, 1=all rejection')
@@ -123,8 +123,8 @@ if __name__ == '__main__':
     cf.zref = args.z_ref
     cf.alpha = args.z_evol
     cf.rej = args.rej
-    cf.no_same_wavelength_pairs = args.no_same_wavelength_pairs
     cf.lambda_abs = constants.absorber_IGM[args.lambda_abs]
+    cf.remove_same_half_plate_close_pairs = args.remove_same_half_plate_close_pairs
     ## use a metal grid equal to the lya grid
     cf.npm = args.np
     cf.ntm = args.nt

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -174,7 +174,7 @@ def dmat(pix):
 
     return wdm,dm.reshape(np*nt,np*nt),npairs,npairs_used
 
-@jit
+#@jit
 def fill_dmat(l1,l2,r1,r2,w1,w2,ang,wdm,dm,order1,order2,same_half_plate):
 
     if x_correlation:

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -174,7 +174,7 @@ def dmat(pix):
 
     return wdm,dm.reshape(np*nt,np*nt),npairs,npairs_used
 
-#@jit
+@jit
 def fill_dmat(l1,l2,r1,r2,w1,w2,ang,wdm,dm,order1,order2,same_half_plate):
 
     if x_correlation:

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -525,7 +525,7 @@ def fill_t123(r1,r2,ang,w1,w2,z1,z2,c1d_1,c1d_2,w123,t123_loc,same_half_plate):
 
     w = (rp<rp_max) & (rt<rt_max) & (rp>=rp_min)
 
-    if remove_same_half_plate_close_pairs same_half_plate:
+    if remove_same_half_plate_close_pairs and same_half_plate:
         w &= abs(rp)>(rp_max-rp_min)/np
 
     bins = bins[w]

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -128,6 +128,10 @@ class data:
         if 'standard asymmetry' in dic_init['model']:
             self.xi_asy_model = partial(getattr(xi, dic_init['model']['standard asymmetry']), name=self.name)
 
+        self.sky_residuals = None
+        if 'sky residuals' in dic_init['model']:
+            self.sky_residuals = partial(getattr(xi, dic_init['model']['sky residuals']), name=self.name, bin_size_rp=bin_size_rp)
+
         self.bb = {}
         self.bb['pre-add'] = []
         self.bb['pos-add'] = []
@@ -290,6 +294,10 @@ class data:
 
         if self.xi_asy_model is not None:
             xi += self.xi_asy_model(self.r, self.mu, k, pk_lin, self.tracer1, self.tracer2, **pars)
+
+        ## Sky residuals correlation
+        if self.sky_residuals is not None:
+            xi += self.sky_residuals(self.r, self.mu, **pars)
 
         ## pre-distortion broadband
         for bb in self.bb['pre-mul']:

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -128,10 +128,6 @@ class data:
         if 'standard asymmetry' in dic_init['model']:
             self.xi_asy_model = partial(getattr(xi, dic_init['model']['standard asymmetry']), name=self.name)
 
-        self.sky_residuals = None
-        if 'sky residuals' in dic_init['model']:
-            self.sky_residuals = partial(getattr(xi, dic_init['model']['sky residuals']), name=self.name, bin_size_rp=bin_size_rp)
-
         self.bb = {}
         self.bb['pre-add'] = []
         self.bb['pos-add'] = []
@@ -155,8 +151,8 @@ class data:
                         for j in range(deg_mu_min, deg_mu_max+1, ddeg_mu)}
 
                 for k,v in bb_pars.items():
-                   dic_init['parameters']['values'][k] = v
-                   dic_init['parameters']['errors']['error_'+k] = 0.01
+                    dic_init['parameters']['values'][k] = v
+                    dic_init['parameters']['errors']['error_'+k] = 0.01
 
                 bb = partial(xi.broadband, deg_r_min=deg_r_min,
                     deg_r_max=deg_r_max, ddeg_r=ddeg_r,
@@ -294,10 +290,6 @@ class data:
 
         if self.xi_asy_model is not None:
             xi += self.xi_asy_model(self.r, self.mu, k, pk_lin, self.tracer1, self.tracer2, **pars)
-
-        ## Sky residuals correlation
-        if self.sky_residuals is not None:
-            xi += self.sky_residuals(self.r, self.mu, **pars)
 
         ## pre-distortion broadband
         for bb in self.bb['pre-mul']:

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -134,7 +134,7 @@ class data:
         self.bb['pre-mul'] = []
         self.bb['pos-mul'] = []
         if 'broadband' in dic_init:
-            for ibb,dic_bb in enumerate(dic_init['broadband']):
+            for ibb,dic_bb in enumerate( [el for el in dic_init['broadband'] if el['func']!='broadband_sky']):
                 deg_r_min = dic_bb['deg_r_min']
                 deg_r_max = dic_bb['deg_r_max']
                 ddeg_r = dic_bb['ddeg_r']
@@ -163,6 +163,22 @@ class data:
                 bb.name = name
 
                 self.bb[dic_bb['pre']+"-"+dic_bb['type']].append(bb)
+
+            size_bb = len(self.bb['pre-add'])+len(self.bb['pos-add'])+len(self.bb['pre-mul'])+len(self.bb['pos-mul'])
+            for ibb,dic_bb in enumerate( [el for el in dic_init['broadband'] if el['func']=='broadband_sky']):
+                ibb += size_bb
+                name = 'BB-{}-{}-{}'.format(self.name,ibb,dic_bb['func'])
+
+                for k in ['scale-sky','sigma-sky']:
+                    if not name+'-'+k in dic_init['parameters']['values']:
+                        dic_init['parameters']['values'][name+'-'+k] = 0.
+                        dic_init['parameters']['errors']['error_'+name+'-'+k] = 0.01
+
+                bb = partial( getattr(xi, dic_bb['func']),
+                    bin_size_rp=bin_size_rp, name=name)
+
+                bb.name = name
+                self.bb[dic_bb['pre']+'-'+dic_bb['type']].append(bb)
 
         self.par_names = dic_init['parameters']['values'].keys()
         self.pars_init = dic_init['parameters']['values']

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -154,7 +154,8 @@ class data:
                     dic_init['parameters']['values'][k] = v
                     dic_init['parameters']['errors']['error_'+k] = 0.01
 
-                bb = partial(xi.broadband, deg_r_min=deg_r_min,
+                bb = partial( getattr(xi, dic_bb['func']),
+                    deg_r_min=deg_r_min,
                     deg_r_max=deg_r_max, ddeg_r=ddeg_r,
                     deg_mu_min=deg_mu_min, deg_mu_max=deg_mu_max,
                     ddeg_mu=ddeg_mu,rp_rt = dic_bb['rp_rt']=='rp,rt',

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -175,7 +175,7 @@ class data:
                         dic_init['parameters']['errors']['error_'+name+'-'+k] = 0.01
 
                 bb = partial( getattr(xi, dic_bb['func']),
-                    bin_size_rp=bin_size_rp, name=name)
+                    bin_size_rp=bin_size_rp, bin_size_rt=bin_size_rt, name=name)
 
                 bb.name = name
                 self.bb[dic_bb['pre']+'-'+dic_bb['type']].append(bb)

--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -159,7 +159,7 @@ class data:
                     deg_r_max=deg_r_max, ddeg_r=ddeg_r,
                     deg_mu_min=deg_mu_min, deg_mu_max=deg_mu_max,
                     ddeg_mu=ddeg_mu,rp_rt = dic_bb['rp_rt']=='rp,rt',
-                    name=name)
+                    bin_size_rp=bin_size_rp, name=name)
                 bb.name = name
 
                 self.bb[dic_bb['pre']+"-"+dic_bb['type']].append(bb)

--- a/py/picca/fitter2/parser.py
+++ b/py/picca/fitter2/parser.py
@@ -155,6 +155,12 @@ def parse_data(filename,zeff,fiducial):
             assert value[2]=='rp,rt' or value[2]=='r,mu'
             dic_bb['rp_rt'] = value[2]
 
+            if len(value)==6:
+                assert value[5] == 'sky'
+                dic_bb['sky'] = value[5]=='sky'
+            else:
+                dic_bb['sky'] = False
+
             deg_r_min,deg_r_max,ddeg_r = value[3].split(':')
             dic_bb['deg_r_min'] = int(deg_r_min)
             dic_bb['deg_r_max'] = int(deg_r_max)

--- a/py/picca/fitter2/parser.py
+++ b/py/picca/fitter2/parser.py
@@ -156,10 +156,9 @@ def parse_data(filename,zeff,fiducial):
             dic_bb['rp_rt'] = value[2]
 
             if len(value)==6:
-                assert value[5] == 'sky'
-                dic_bb['sky'] = value[5]=='sky'
+                dic_bb['func'] = value[5]
             else:
-                dic_bb['sky'] = False
+                dic_bb['func'] = 'broadband'
 
             deg_r_min,deg_r_max,ddeg_r = value[3].split(':')
             dic_bb['deg_r_min'] = int(deg_r_min)

--- a/py/picca/fitter2/xi.py
+++ b/py/picca/fitter2/xi.py
@@ -231,28 +231,54 @@ def qso_bias_vs_z_croom(z, tracer, zref = None, **kwargs):
     p1 = kwargs["croom_par1"]
     return (p0 + p1*(1.+z)**2)/(p0 + p1*(1+zref)**2)
 
-def sky_residual_correlation(r, mu, name, bin_size_rp, *pars, **kwargs):
-    '''Contribution to the correlation of delta field
-        by the sky residuals
+def broadband_sky(r, mu, bin_size_rp, deg_r_min=None, deg_r_max=None,
+        ddeg_r=None, deg_mu_min=None, deg_mu_max=None,
+        ddeg_mu=None, deg_mu=None, name=None,
+        rp_rt=False, *pars, **kwargs):
+    '''
+        Broadband function interface.
+        Calculates a power-law broadband in r and mu or rp,rt for the sky residuals
+    Arguments:
+        - r,mu: (array or float) where to calcualte the broadband
+        - deg_r_min: (int) degree of the lowest-degree monomial in r or rp
+        - deg_r_max: (int) degree of the highest-degree monomual in r or rp
+        - ddeg_r: (int) degree step in r or rp
+        - deg_mu_min: (int) degree of the lowest-degree monomial in mu or rt
+        - deg_mu_max: (int) degree of the highest-degree monmial in mu or rt
+        - ddeg_mu: (int) degree step in mu or rt
+        - name: (string) name ot identify the corresponding parameters,
+                    typically the dataset name and whether it's multiplicative
+                    of additive
+        - rt_rp: (bool) use r,mu (if False) or rp,rt (if True)
+        - *pars: additional parameters that are ignored (for convenience)
+        **kwargs: (dict) dictionary containing all the polynomial
+                    coefficients. Any extra keywords are ignored
 
-        Arguments:
-            - r (array or float): separation
-            - mu (array or float): cosnus of angle
-            - name (str): name of the correlation
-            - bin_size_rp (float): size of the bin in r-parallel
-            - *pars: additional parameters that are ignored (for convenience)
-            - **kwargs: (dict) dictionary containing all the polynomial
-                coefficients. Any extra keywords are ignored
-        Returns:
-            cor (array of float): Correlation
+    Returns:
+        - cor (array of float): Correlation function
     '''
 
     rp = mu*r
     rt = sp.sqrt(r**2-rp**2)
 
-    cor = sp.zeros(r.size)
+    if rp_rt:
+        r1 = (r/100.)*mu
+        r2 = (r/100.)*sp.sqrt(1-mu**2)
+    else:
+        r1 = r/100.
+        r2 = mu
+
+    r1_pows = sp.arange(deg_r_min, deg_r_max+1, ddeg_r)
+    r2_pows = sp.arange(deg_mu_min, deg_mu_max+1, ddeg_mu)
+    BB = [kwargs['{} ({},{})'.format(name,i,j)] for i in r1_pows
+            for j in r2_pows]
+    BB = sp.array(BB).reshape(-1,deg_r_max-deg_r_min+1)
+
+    cor = (BB[:,:,None,None]*r1**r1_pows[:,None,None]*\
+            r2**r2_pows[None,:,None]).sum(axis=(0,1,2))
+
     w = (rp>=0.) & (rp<bin_size_rp)
-    cor[w] = kwargs['scale_sky '+name]*(1.+rt[w])**kwargs['gamma_sky '+name]
+    cor[~w] = 0.
 
     return cor
 

--- a/py/picca/fitter2/xi.py
+++ b/py/picca/fitter2/xi.py
@@ -231,13 +231,14 @@ def qso_bias_vs_z_croom(z, tracer, zref = None, **kwargs):
     p1 = kwargs["croom_par1"]
     return (p0 + p1*(1.+z)**2)/(p0 + p1*(1+zref)**2)
 
-def broadband_sky(r, mu, name=None, bin_size_rp=None, *pars, **kwargs):
+def broadband_sky(r, mu, name=None, bin_size_rp=None, bin_size_rt=None, *pars, **kwargs):
     '''
         Broadband function interface.
         Calculates a Gaussian broadband in rp,rt for the sky residuals
     Arguments:
         - r,mu (array or float): where to calcualte the broadband
-        - bin_size_rp (array): Bin size of the distortion matrix
+        - bin_size_rp (array): Bin size of the distortion matrix along the line-of-sight
+        - bin_size_rt (array): Bin size of the distortion matrix across the line-of-sight
         - name: (string) name ot identify the corresponding parameters,
                     typically the dataset name and whether it's multiplicative
                     of additive
@@ -250,7 +251,7 @@ def broadband_sky(r, mu, name=None, bin_size_rp=None, *pars, **kwargs):
 
     rp = r*mu
     rt = r*sp.sqrt(1-mu**2)
-    cor = kwargs[name+'-scale-sky']*sp.exp(-(rt/bin_size_rp)**2/kwargs[name+'-sigma-sky']**2)
+    cor = kwargs[name+'-scale-sky']*sp.exp(-(rt/bin_size_rt)**2/kwargs[name+'-sigma-sky']**2)
     w = (rp>=0.) & (rp<bin_size_rp)
     cor[~w] = 0.
 

--- a/py/picca/fitter2/xi.py
+++ b/py/picca/fitter2/xi.py
@@ -232,6 +232,20 @@ def qso_bias_vs_z_croom(z, tracer, zref = None, **kwargs):
     return (p0 + p1*(1.+z)**2)/(p0 + p1*(1+zref)**2)
 
 def sky_residual_correlation(r, mu, name, bin_size_rp, *pars, **kwargs):
+    '''Contribution to the correlation of delta field
+        by the sky residuals
+
+        Arguments:
+            - r (array or float): separation
+            - mu (array or float): cosnus of angle
+            - name (str): name of the correlation
+            - bin_size_rp (float): size of the bin in r-parallel
+            - *pars: additional parameters that are ignored (for convenience)
+            - **kwargs: (dict) dictionary containing all the polynomial
+                coefficients. Any extra keywords are ignored
+        Returns:
+            cor (array of float): Correlation
+    '''
 
     rp = mu*r
     rt = sp.sqrt(r**2-rp**2)

--- a/py/picca/fitter2/xi.py
+++ b/py/picca/fitter2/xi.py
@@ -231,6 +231,16 @@ def qso_bias_vs_z_croom(z, tracer, zref = None, **kwargs):
     p1 = kwargs["croom_par1"]
     return (p0 + p1*(1.+z)**2)/(p0 + p1*(1+zref)**2)
 
+def sky_residual_correlation(r, mu, name, bin_size_rp, *pars, **kwargs):
+
+    rp = mu*r
+    rt = sp.sqrt(r**2-rp**2)
+
+    cor = sp.zeros(r.size)
+    w = (rp>=0.) & (rp<bin_size_rp)
+    cor[w] = kwargs['scale_sky '+name]*(1.+rt[w])**kwargs['gamma_sky '+name]
+
+    return cor
 
 def broadband(r, mu, deg_r_min=None, deg_r_max=None,
         ddeg_r=None, deg_mu_min=None, deg_mu_max=None,

--- a/py/picca/fitter2/xi.py
+++ b/py/picca/fitter2/xi.py
@@ -231,52 +231,26 @@ def qso_bias_vs_z_croom(z, tracer, zref = None, **kwargs):
     p1 = kwargs["croom_par1"]
     return (p0 + p1*(1.+z)**2)/(p0 + p1*(1+zref)**2)
 
-def broadband_sky(r, mu, deg_r_min=None, deg_r_max=None,
-        ddeg_r=None, deg_mu_min=None, deg_mu_max=None,
-        ddeg_mu=None, deg_mu=None, name=None,
-        rp_rt=False, bin_size_rp=None, *pars, **kwargs):
+def broadband_sky(r, mu, name=None, bin_size_rp=None, *pars, **kwargs):
     '''
         Broadband function interface.
-        Calculates a power-law broadband in r and mu or rp,rt for the sky residuals
+        Calculates a Gaussian broadband in rp,rt for the sky residuals
     Arguments:
-        - r,mu: (array or float) where to calcualte the broadband
-        - deg_r_min: (int) degree of the lowest-degree monomial in r or rp
-        - deg_r_max: (int) degree of the highest-degree monomual in r or rp
-        - ddeg_r: (int) degree step in r or rp
-        - deg_mu_min: (int) degree of the lowest-degree monomial in mu or rt
-        - deg_mu_max: (int) degree of the highest-degree monmial in mu or rt
-        - ddeg_mu: (int) degree step in mu or rt
+        - r,mu (array or float): where to calcualte the broadband
+        - bin_size_rp (array): Bin size of the distortion matrix
         - name: (string) name ot identify the corresponding parameters,
                     typically the dataset name and whether it's multiplicative
                     of additive
-        - rt_rp: (bool) use r,mu (if False) or rp,rt (if True)
         - *pars: additional parameters that are ignored (for convenience)
-        **kwargs: (dict) dictionary containing all the polynomial
+        **kwargs (dict): dictionary containing all the polynomial
                     coefficients. Any extra keywords are ignored
-
     Returns:
         - cor (array of float): Correlation function
     '''
 
-    rp = mu*r
-    rt = sp.sqrt(r**2-rp**2)
-
-    if rp_rt:
-        r1 = (r/100.)*mu
-        r2 = (r/100.)*sp.sqrt(1-mu**2)
-    else:
-        r1 = r/100.
-        r2 = mu
-
-    r1_pows = sp.arange(deg_r_min, deg_r_max+1, ddeg_r)
-    r2_pows = sp.arange(deg_mu_min, deg_mu_max+1, ddeg_mu)
-    BB = [kwargs['{} ({},{})'.format(name,i,j)] for i in r1_pows
-            for j in r2_pows]
-    BB = sp.array(BB).reshape(-1,deg_r_max-deg_r_min+1)
-
-    cor = (BB[:,:,None,None]*r1**r1_pows[:,None,None]*\
-            r2**r2_pows[None,:,None]).sum(axis=(0,1,2))
-
+    rp = r*mu
+    rt = r*sp.sqrt(1-mu**2)
+    cor = kwargs[name+'-scale-sky']*sp.exp(-(rt/bin_size_rp)**2/kwargs[name+'-sigma-sky']**2)
     w = (rp>=0.) & (rp<bin_size_rp)
     cor[~w] = 0.
 

--- a/py/picca/fitter2/xi.py
+++ b/py/picca/fitter2/xi.py
@@ -231,10 +231,10 @@ def qso_bias_vs_z_croom(z, tracer, zref = None, **kwargs):
     p1 = kwargs["croom_par1"]
     return (p0 + p1*(1.+z)**2)/(p0 + p1*(1+zref)**2)
 
-def broadband_sky(r, mu, bin_size_rp, deg_r_min=None, deg_r_max=None,
+def broadband_sky(r, mu, deg_r_min=None, deg_r_max=None,
         ddeg_r=None, deg_mu_min=None, deg_mu_max=None,
         ddeg_mu=None, deg_mu=None, name=None,
-        rp_rt=False, *pars, **kwargs):
+        rp_rt=False, bin_size_rp=None, *pars, **kwargs):
     '''
         Broadband function interface.
         Calculates a power-law broadband in r and mu or rp,rt for the sky residuals
@@ -285,7 +285,7 @@ def broadband_sky(r, mu, bin_size_rp, deg_r_min=None, deg_r_max=None,
 def broadband(r, mu, deg_r_min=None, deg_r_max=None,
         ddeg_r=None, deg_mu_min=None, deg_mu_max=None,
         ddeg_mu=None, deg_mu=None, name=None,
-        rp_rt=False, *pars, **kwargs):
+        rp_rt=False, bin_size_rp=None, *pars, **kwargs):
     '''
     Broadband function interface.
     Calculates a power-law broadband in r and mu or rp,rt

--- a/py/picca/test/test_cor.py
+++ b/py/picca/test/test_cor.py
@@ -475,6 +475,7 @@ class TestCor(unittest.TestCase):
         cmd += " --np 15"
         cmd += " --nt 15"
         cmd += " --nproc 1"
+        cmd += ' --remove-same-half-plate-close-pairs'
         subprocess.call(cmd, shell=True)
 
         ### Test
@@ -498,6 +499,7 @@ class TestCor(unittest.TestCase):
         cmd += " --nt 15"
         cmd += " --rej 0.99 "
         cmd += " --nproc 1"
+        cmd += ' --remove-same-half-plate-close-pairs'
         subprocess.call(cmd, shell=True)
 
         ### Test
@@ -522,6 +524,7 @@ class TestCor(unittest.TestCase):
         cmd += " --nt 15"
         cmd += " --rej 0.99 "
         cmd += " --nproc 1"
+        cmd += ' --remove-same-half-plate-close-pairs'
         subprocess.call(cmd, shell=True)
 
         ### Test
@@ -556,6 +559,7 @@ class TestCor(unittest.TestCase):
         cmd += " --np 30"
         cmd += " --nt 15"
         cmd += " --nproc 1"
+        cmd += ' --remove-same-half-plate-close-pairs'
         subprocess.call(cmd, shell=True)
 
         ### Test
@@ -580,6 +584,7 @@ class TestCor(unittest.TestCase):
         cmd += " --nt 15"
         cmd += " --rej 0.99 "
         cmd += " --nproc 1"
+        cmd += ' --remove-same-half-plate-close-pairs'
         subprocess.call(cmd, shell=True)
 
         ### Test
@@ -606,6 +611,7 @@ class TestCor(unittest.TestCase):
         cmd += " --nt 15"
         cmd += " --rej 0.99 "
         cmd += " --nproc 1"
+        cmd += ' --remove-same-half-plate-close-pairs'
         subprocess.call(cmd, shell=True)
 
         ### Test

--- a/py/picca/xcf.py
+++ b/py/picca/xcf.py
@@ -218,7 +218,7 @@ def dmat(pix):
 
     return wdm,dm.reshape(np*nt,np*nt),npairs,npairs_used
 
-#@jit
+@jit
 def fill_dmat(l1,r1,w1,r2,w2,ang,wdm,dm):
     rp = (r1[:,None]-r2)*sp.cos(ang/2)
     rt = (r1[:,None]+r2)*sp.sin(ang/2)

--- a/py/picca/xcf.py
+++ b/py/picca/xcf.py
@@ -218,7 +218,7 @@ def dmat(pix):
 
     return wdm,dm.reshape(np*nt,np*nt),npairs,npairs_used
 
-@jit
+#@jit
 def fill_dmat(l1,r1,w1,r2,w2,ang,wdm,dm):
     rp = (r1[:,None]-r2)*sp.cos(ang/2)
     rt = (r1[:,None]+r2)*sp.sin(ang/2)


### PR DESCRIPTION
Fix issue https://github.com/igmhub/picca/issues/509, by keeping all possible pairs between delta and fitting the contribution of sky residuals in fitter2 by a function that is zero everywhere, except where rp==0.

Here are the results of the fit to the three correlations presented in https://github.com/igmhub/picca/issues/509, computed on the (rp,rt) grid assuming MgII absorption:
- MgII11 = left of MgII emission line: [260,276] nm
- calib = right of MgII emission line: [290,312] nm

The fit runs for all pairs from 10 h-1Mpc to 160h-1Mpc.
Currently the function is a power-law with two parameters, but it doesn't seem to do perfectly the trick.
We have to work on a better function.
It flattens out all small separation.

```
 ||                           || 10^{4} (b\beta)_{\mathrm{MgII(2796)}}/f || gamma_sky   || scale_sky   ||                      || 
 || MGII(MGII11)xMGII(MGII11) || 0.0 +/- 21.0         || -1.582 +/- 0.045     || 0.00091 +/- 0.00012  || 1358.53 / (1252-3),  p = 0.016 || 
 || MGII(calib)xMGII(calib)   || 0.0 +/- 16.0         || -1.485 +/- 0.044     || 0.000536 +/- 7.2e-5 || 1394.34 / (1252-3),  p = 0.0024 || 
 || MGII(MGII11)xMGII(calib)  || -0.0 +/- 5.7         || -1.464 +/- 0.023     || 0.000843 +/- 6.1e-5 || 2842.28 / (2504-3),  p = 1.8e-6 || 
```

![systematic_fit_rp_0](https://user-images.githubusercontent.com/3166436/49603740-56dc3100-f949-11e8-9c5e-f45f1dc3040c.png)

![systematic_fit_rp_1](https://user-images.githubusercontent.com/3166436/49603739-56dc3100-f949-11e8-8754-642a85d55c94.png)
