### PR TITLE
fix issue with numba and llvmlite in tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ numpy==1.13.1
 iminuit==1.2
 healpy==1.11
 fitsio==0.9.11
-numba==0.35.0
+numba==0.41.0
+llvmlite==0.26.0
 h5py==2.6.0
 future==0.16.0
 setuptools==27.2.0


### PR DESCRIPTION
Update the required version of numba and llvmlite to solve the issue with numba in the current run of do_dmat and do_xdmat. The issue was linked to the updated version of llvmlite (=0.27.0), as of December the 31th, that has a bug: https://github.com/numba/numba/issues/3666.