### PR TITLE
compute unfold cf 

### DIFF
--- a/bin/do_cf.py
+++ b/bin/do_cf.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
 
     parser.add_argument('--unfold-cf', action='store_true', required=False,
         help='rp can be positive or negative depending on the relative position between absorber1 and absorber2')
-    
+
     args = parser.parse_args()
 
     if args.nproc is None:

--- a/bin/do_cf.py
+++ b/bin/do_cf.py
@@ -9,7 +9,7 @@ from picca import constants, cf, utils, io
 from picca.utils import print
 
 def corr_func(p):
-    if cf.x_correlation:
+    if args.in_dir2:
         cf.fill_neighs_x_correlation(p)
     else:
         cf.fill_neighs(p)
@@ -89,7 +89,9 @@ if __name__ == '__main__':
     parser.add_argument('--nspec', type=int, default=None, required=False,
         help='Maximum number of spectra to read')
 
-
+    parser.add_argument('--unfold-cf', action='store_true', required=False,
+        help='rp can be positive or negative depending on the relative position between absorber1 and absorber2')
+    
     args = parser.parse_args()
 
     if args.nproc is None:
@@ -120,8 +122,9 @@ if __name__ == '__main__':
     print("done, npix = {}".format(cf.npix))
 
     ### Read data 2
-    if args.in_dir2 or args.lambda_abs2:
-        cf.x_correlation = True
+    if args.in_dir2 or args.lambda_abs2 :
+        if args.lambda_abs2 or args.unfold_cf:
+            cf.x_correlation = True
         cf.alpha2 = args.z_evol2
         if args.in_dir2 is None:
             args.in_dir2 = args.in_dir

--- a/bin/do_dmat.py
+++ b/bin/do_dmat.py
@@ -9,7 +9,7 @@ from picca import constants, cf, utils, io
 from picca.utils import print
 
 def calc_dmat(p):
-    if cf.x_correlation:
+    if args.in_dir2:
         cf.fill_neighs_x_correlation(p)
     else:
         cf.fill_neighs(p)
@@ -91,6 +91,8 @@ if __name__ == '__main__':
     parser.add_argument('--nspec', type=int, default=None, required=False,
         help='Maximum number of spectra to read')
 
+    parser.add_argument('--unfold-cf', action='store_true', required=False,
+        help='rp can be positive or negative depending on the relative position between absorber1 and absorber2')
 
     args = parser.parse_args()
 
@@ -126,7 +128,8 @@ if __name__ == '__main__':
 
     ### Read data 2
     if args.in_dir2 or args.lambda_abs2:
-        cf.x_correlation = True
+        if args.lambda_abs2 or args.unfold_cf:
+            cf.x_correlation = True
         cf.alpha2 = args.z_evol2
         if args.in_dir2 is None:
             args.in_dir2 = args.in_dir

--- a/bin/do_metal_dmat.py
+++ b/bin/do_metal_dmat.py
@@ -10,7 +10,7 @@ from picca import constants, cf, utils, io
 from picca.utils import print
 
 def calc_metal_dmat(abs_igm1,abs_igm2,p):
-    if cf.x_correlation:
+    if args.in_dir2:
         cf.fill_neighs_x_correlation(p)
     else:
         cf.fill_neighs(p)
@@ -98,6 +98,8 @@ if __name__ == '__main__':
     parser.add_argument('--nspec', type=int, default=None, required=False,
         help='Maximum number of spectra to read')
 
+    parser.add_argument('--unfold-cf', action='store_true', required=False,
+        help='rp can be positive or negative depending on the relative position between absorber1 and absorber2')
 
     args = parser.parse_args()
 
@@ -142,7 +144,8 @@ if __name__ == '__main__':
 
     ### Read data 2
     if args.in_dir2 or args.lambda_abs2:
-        cf.x_correlation = True
+        if args.lambda_abs2 or args.unfold_cf:
+            cf.x_correlation = True
         cf.alpha2 = args.z_evol2
         if args.in_dir2 is None:
             args.in_dir2 = args.in_dir

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -109,8 +109,9 @@ def fast_cf(z1,r1,w1,d1,z2,r2,w2,d2,ang,same_half_plate):
             rp[(rp<1.)] = 1./rp[(rp<1.)]
         rt = ang*sp.ones_like(rp)
     else:
-        if x_correlation : rp = (r1-r2[:,None])*sp.cos(ang/2)
-        else : rp = abs(r1-r2[:,None])*sp.cos(ang/2)
+        rp = (r1-r2[:,None])*sp.cos(ang/2)
+        if not x_correlation :
+            rp = abs(rp)
         rt = (r1+r2[:,None])*sp.sin(ang/2)
     wd12 = wd1*wd2[:,None]
     w12 = w1*w2[:,None]
@@ -183,10 +184,9 @@ def dmat(pix):
 @jit
 def fill_dmat(l1,l2,r1,r2,w1,w2,ang,wdm,dm,same_half_plate,order1,order2):
 
-    if x_correlation:
-        rp = (r1[:,None]-r2)*sp.cos(ang/2)
-    else:
-        rp = abs(r1[:,None]-r2)*sp.cos(ang/2)
+    rp = (r1[:,None]-r2)*sp.cos(ang/2)
+    if  not x_correlation:
+        rp = abs(rp)
     rt = (r1[:,None]+r2)*sp.sin(ang/2)
     bp = sp.floor((rp-rp_min)/(rp_max-rp_min)*np).astype(int)
     bt = (rt/rt_max*nt).astype(int)
@@ -535,10 +535,9 @@ def fill_t123(r1,r2,ang,w1,w2,z1,z2,c1d_1,c1d_2,w123,t123_loc,same_half_plate):
     zw2 = ((1+z2)/(1+zref))**(alpha-1)
 
     bins = i1[:,None]+n1*i2
-    if x_correlation:
-        rp = (r1[:,None]-r2)*sp.cos(ang/2)
-    else :
-        rp = abs(r1[:,None]-r2)*sp.cos(ang/2)
+    rp = (r1[:,None]-r2)*sp.cos(ang/2)
+    if not x_correlation:
+        rp = abs(rp)
     rt = (r1[:,None]+r2)*sp.sin(ang/2)
     bp = sp.floor((rp-rp_min)/(rp_max-rp_min)*np).astype(int)
     bt = (rt/rt_max*nt).astype(int)

--- a/py/picca/test/test_cor.py
+++ b/py/picca/test/test_cor.py
@@ -556,6 +556,7 @@ class TestCor(unittest.TestCase):
         cmd += " --np 30"
         cmd += " --nt 15"
         cmd += " --nproc 1"
+        cmd += " --unfold-cf"
         subprocess.call(cmd, shell=True)
 
         ### Test
@@ -580,6 +581,7 @@ class TestCor(unittest.TestCase):
         cmd += " --nt 15"
         cmd += " --rej 0.99 "
         cmd += " --nproc 1"
+        cmd += " --unfold-cf"
         subprocess.call(cmd, shell=True)
 
         ### Test
@@ -606,6 +608,7 @@ class TestCor(unittest.TestCase):
         cmd += " --nt 15"
         cmd += " --rej 0.99 "
         cmd += " --nproc 1"
+        cmd += " --unfold-cf"
         subprocess.call(cmd, shell=True)
 
         ### Test


### PR DESCRIPTION
Add modifications in the computation of symmetric cfs such as lya(lya)xlya(lyb). 
Standardly, we compute this cf with rp = abs(rp) 
But we can also have rp positive or negative (depending on the relative position between abs1 and abs2) by adding the "unfold-cf" option