### PR TITLE
correct DeprecationWarning from ConfigParser

### DIFF
--- a/py/picca/test/test_cor.py
+++ b/py/picca/test/test_cor.py
@@ -19,7 +19,7 @@ else:
 def update_system_status_values(path, section, system, value):
 
     ### Make ConfigParser case sensitive
-    class CaseConfigParser(ConfigParser.SafeConfigParser):
+    class CaseConfigParser(ConfigParser.ConfigParser):
         def optionxform(self, optionstr):
             return optionstr
     cp = CaseConfigParser()


### PR DESCRIPTION
Correct the following warning:
```
test_cor.py:25: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  cp = CaseConfigParser()
```