### PR TITLE
Checking on diff reso coaddition

### DIFF
--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -224,7 +224,6 @@ class forest(qso):
 
         return self
 
-
     def mask(self,mask_obs,mask_RF):
         if not hasattr(self,'ll'):
             return

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -189,7 +189,7 @@ class forest(qso):
         self.mean_z = (sp.power(10.,ll[len(ll)-1])+sp.power(10.,ll[0]))/2./lam_lya -1.0
 
 
-def __add__(self, d):
+    def __add__(self, d):
 
         if not hasattr(self, 'll') or not hasattr(d, 'll'):
             return self

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -207,12 +207,12 @@ class forest(qso):
         if self.reso is not None:
             dic['reso'] = sp.append(self.reso, d.reso)
 
-        bins = sp.floor((ll - forest.lmin) / forest.dll + 0.5).astype(int)
-        cll = forest.lmin + sp.arange(bins.max() + 1) * forest.dll
-        civ = sp.zeros(bins.max() + 1)
-        cciv = sp.bincount(bins, weights=iv)
+        bins = sp.floor((ll-forest.lmin)/forest.dll+0.5).astype(int)
+        cll = forest.lmin + sp.arange(bins.max()+1)*forest.dll
+        civ = sp.zeros(bins.max()+1)
+        cciv = sp.bincount(bins,weights=iv)
         civ[:len(cciv)] += cciv
-        w = (civ > 0.)
+        w = (civ>0.)
         self.ll = cll[w]
         self.iv = civ[w]
 

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -189,16 +189,16 @@ class forest(qso):
         self.mean_z = (sp.power(10.,ll[len(ll)-1])+sp.power(10.,ll[0]))/2./lam_lya -1.0
 
 
-    def __add__(self, d):
+    def __add__(self,d):
 
-        if not hasattr(self, 'll') or not hasattr(d, 'll'):
+        if not hasattr(self,'ll') or not hasattr(d,'ll'):
             return self
 
         dic = {}  # this should contain all quantities that are to be coadded with ivar weighting
 
-        ll = sp.append(self.ll, d.ll)
+        ll = sp.append(self.ll,d.ll)
         dic['fl'] = sp.append(self.fl, d.fl)
-        iv = sp.append(self.iv, d.iv)
+        iv = sp.append(self.iv,d.iv)
 
         if self.mmef is not None:
             dic['mmef'] = sp.append(self.mmef, d.mmef)


### PR DESCRIPTION
closes #325
I changed the coaddition of forests such that reso and diff are coadded as well just doing inverse variance weighting. This will prevent code from crashing, but might not be the optimal solution, so we might want to change the way this is done at a later time
Also restructured the whole __add__ routine responsable for the coadding in the following way:

- lambda and ivar are treated as before
- all other fields to be coadded (atm flux, mmef, diff and reso) are fed into a dictionary which is then looped over, each is coadded with inverse variance weighting. 
- So for flux nothing should change as it was done this way before
- for mmef the coaddition was done with iv*mmef, but there was no renormalization by the new iv, which I think was erroneous, but please double check
- for diff and reso the same inverse variance weighted coaddition is performed now
- if any other quantity should be added later and coaddition should be performed the same way it just needs to be added to the dict