### PR TITLE
When RPDM are not in second HDU

### DIFF
--- a/py/picca/fitter2/data.py
+++ b/py/picca/fitter2/data.py
@@ -41,7 +41,7 @@ class data:
             dmrp = h[2]['DMRP'][:]
             dmrt = h[2]['DMRT'][:]
             dmz = h[2]['DMZ'][:]
-        except IOError:
+        except (IOError, ValueError):
             dmrp = rp.copy()
             dmrt = rt.copy()
             dmz = z.copy()


### PR DESCRIPTION
for the auto-correlation of quasars, the exported correlation has a second hdu,
but it does not give the non-squared distortion matrix, but simply the individual
correlation in each sub-sample, to allow for cross-covariance matrix estimation.
This PR allows still to fit the auto-correlation of quasars by catching the proper exception.