### PR TITLE
Read DLA from fits file

### DIFF
--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -17,30 +17,35 @@ class metadata:
     pass
 
 def read_dlas(fdla):
-    f=open(os.path.expandvars(fdla))
-    dlas={}
-    nb_dla = 0
-    col_names=None
-    for l in f:
-        l = l.split()
-        if len(l)==0:continue
-        if l[0][0]=="#":continue
-        if l[0]=="ThingID":
-            col_names = l
-            continue
-        if l[0][0]=="-":continue
-        thid = int(l[col_names.index("ThingID")])
-        if thid not in dlas:
-            dlas[thid]=[]
-        zabs = float(l[col_names.index("z_abs")])
-        nhi = float(l[col_names.index("NHI")])
-        dlas[thid].append((zabs,nhi))
-        nb_dla += 1
+    """
+    Read the DLA catalog from a fits file.
+    ASCII or DESI files can be converted using:
+        utils.eBOSS_convert_DLA()
+        utils.desi_convert_DLA()
+    """
 
-    print("")
-    print(" In catalog: {} DLAs".format(nb_dla) )
-    print(" In catalog: {} forests have a DLA".format(len(dlas)) )
-    print("")
+    lst = ['THING_ID','Z','NHI']
+    h = fitsio.FITS(fdla)
+    cat = { k:h['DLACAT'][k][:] for k in lst }
+    h.close()
+
+    w = sp.argsort(cat['Z'])
+    for k in cat.keys():
+        cat[k] = cat[k][w]
+    w = sp.argsort(cat['THING_ID'])
+    for k in cat.keys():
+        cat[k] = cat[k][w]
+
+    dlas = {}
+    for t in sp.unique(cat['THING_ID']):
+        w = t==cat['THING_ID']
+        dlas[t] = [ (z,nhi) for z,nhi in zip(cat['Z'][w],cat['NHI'][w]) ]
+    nb_dla = sp.sum([len(d) for d in dlas.values()])
+
+    print('\n')
+    print(' In catalog: {} DLAs'.format(nb_dla) )
+    print(' In catalog: {} forests have a DLA'.format(len(dlas)) )
+    print('\n')
 
     return dlas
 

--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -95,7 +95,7 @@ def eBOSS_convert_DLA(inPath,drq,outPath,drqzkey='Z'):
                 dcat[kk] = []
             continue
         else:
-            for k,idx in fromkeytoindex.items():
+            for k in fromkeytoindex.keys():
                 v = l[fromkeytoindex[k]]
                 if k=='MJD-plate-fiber':
                     v = v.split('-')

--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -173,6 +173,7 @@ def desi_convert_DLA(inPath,outPath):
     for k,v in fromDESIkey2piccaKey.items():
         cat[k] = h['DLACAT'][v][:]
     h.close()
+    print('INFO: Found {} DLA from {} quasars'.format(cat['Z'].size, sp.unique(cat['THING_ID']).size))
 
     ### Save
     out = fitsio.FITS(outPath,'rw',clobber=True)


### PR DESCRIPTION
Read DLA from fits file, fix issue https://github.com/igmhub/picca/issues/571.
The idea is to read DLAs from a fits file, to be able to use DESI mocks.
To convert the BOSS and eBOSS catalogs, I added the function `utils.eBOSS_convert_DLA()` and
to convert the DESI mocks, I added the function `utils.desi_convert_DLA()`.
@alxogm, would that be good for you? Could you try running `utils.desi_convert_DLA()`? It is very similar to the already existing function `desi_from_ztarget_to_drq()` we use fro quasars.