### PR TITLE
cast ra, dec, z to float64

### DIFF
--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -13,8 +13,8 @@ def variance(var,eta,var_lss,fudge):
 
 class qso:
     def __init__(self,thid,ra,dec,zqso,plate,mjd,fiberid):
-        self.ra = ra
-        self.dec = dec
+        self.ra = ra.astype(sp.float64)
+        self.dec = dec.astype(sp.float64)
 
         self.plate=plate
         self.mjd=mjd
@@ -26,7 +26,7 @@ class qso:
         self.zcart = sp.sin(dec)
         self.cosdec = sp.cos(dec)
 
-        self.zqso = zqso
+        self.zqso = zqso.astype(sp.float64)
         self.thid = thid
 
     def __xor__(self,data):
@@ -183,9 +183,9 @@ class forest(qso):
         #if diff is not None :
         self.diff = diff
         self.reso = reso
-#        else :
-#           self.diff = sp.zeros(len(ll))
-#           self.reso = sp.ones(len(ll))
+        #else :
+        #   self.diff = sp.zeros(len(ll))
+        #   self.reso = sp.ones(len(ll))
 
         # compute means
         if reso is not None : self.mean_reso = sum(reso)/float(len(reso))

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -13,8 +13,8 @@ def variance(var,eta,var_lss,fudge):
 
 class qso:
     def __init__(self,thid,ra,dec,zqso,plate,mjd,fiberid):
-        self.ra = ra.astype(sp.float64)
-        self.dec = dec.astype(sp.float64)
+        self.ra = ra
+        self.dec = dec
 
         self.plate=plate
         self.mjd=mjd
@@ -26,7 +26,7 @@ class qso:
         self.zcart = sp.sin(dec)
         self.cosdec = sp.cos(dec)
 
-        self.zqso = zqso.astype(sp.float64)
+        self.zqso = zqso
         self.thid = thid
 
     def __xor__(self,data):
@@ -484,9 +484,9 @@ class delta(qso):
         de = h[0].read()
         iv = h[1].read()
         ll = h[2].read()
-        ra = h[3]["RA"][:]*sp.pi/180.
-        dec = h[3]["DEC"][:]*sp.pi/180.
-        z = h[3]["Z"][:]
+        ra = h[3]["RA"][:].astype(sp.float64)*sp.pi/180.
+        dec = h[3]["DEC"][:].astype(sp.float64)*sp.pi/180.
+        z = h[3]["Z"][:].astype(sp.float64)
         plate = h[3]["PLATE"][:]
         mjd = h[3]["MJD"][:]
         fid = h[3]["FIBER"]


### PR DESCRIPTION
Fix issue https://github.com/igmhub/picca/issues/576, by casting RA, DEC and Z to float64.
Fix error message `WARNING: 1 pairs have cos>=1.`