### PR TITLE
Add optical depth

### DIFF
--- a/bin/picca_deltas.py
+++ b/bin/picca_deltas.py
@@ -96,7 +96,7 @@ if __name__ == '__main__':
         help='Path to file to mask regions in lambda_OBS and lambda_RF. In file each line is: region_name region_min region_max (OBS or RF) [Angstrom]')
 
     parser.add_argument('--optical-depth', type=str, default=None, required=False,
-        help='Correct for the optical depth: tau_1, gamma_1, waveRF_1, tau_2, gamma_2, waveRF_2', nargs='*')
+        help='Correct for the optical depth: tau_1, gamma_1, absorber_1, tau_2, gamma_2, absorber_2, ...', nargs='*')
 
     parser.add_argument('--dust-map', type=str, default=None, required=False,
         help='Path to DRQ catalog of objects for dust map to apply the Schlegel correction')
@@ -257,7 +257,7 @@ if __name__ == '__main__':
 
     ### Veto absorbers
     if not args.absorber_vac is None:
-        print("adding absorbers")
+        print("INFO: Adding absorbers")
         absorbers = io.read_absorbers(args.absorber_vac)
         nb_absorbers_in_forest = 0
         for p in data:
@@ -270,14 +270,13 @@ if __name__ == '__main__':
 
     ### Apply optical depth
     if not args.optical_depth is None:
-        print("INFO: Adding optical depth")
-        assert args.optical_depth%3==0
-        for idxop in range(args.optical_depth//3):
+        print("INFO: Adding {} optical depths".format(len(args.optical_depth)//3))
+        assert len(args.optical_depth)%3==0
+        for idxop in range(len(args.optical_depth)//3):
             tau = float(args.optical_depth[3*idxop])
             gamma = float(args.optical_depth[3*idxop+1])
             waveRF = constants.absorber_IGM[args.optical_depth[3*idxop+2]]
             print("INFO: Adding optical depth for tau = {}, gamma = {}, waveRF = {} A".format(tau,gamma,waveRF))
-            print(tau,gamma,waveRF)
             for p in data:
                 for d in data[p]:
                     d.add_optical_depth(tau,gamma,waveRF)

--- a/bin/picca_deltas.py
+++ b/bin/picca_deltas.py
@@ -96,7 +96,7 @@ if __name__ == '__main__':
         help='Path to file to mask regions in lambda_OBS and lambda_RF. In file each line is: region_name region_min region_max (OBS or RF) [Angstrom]')
 
     parser.add_argument('--optical-depth', type=str, default=None, required=False,
-        help='Correct for the optical depth: tau_1, gamma_1, absorber_1, tau_2, gamma_2, absorber_2, ...', nargs='*')
+        help='Correct for the optical depth: tau_1 gamma_1 absorber_1 tau_2 gamma_2 absorber_2 ...', nargs='*')
 
     parser.add_argument('--dust-map', type=str, default=None, required=False,
         help='Path to DRQ catalog of objects for dust map to apply the Schlegel correction')

--- a/bin/picca_deltas.py
+++ b/bin/picca_deltas.py
@@ -441,8 +441,6 @@ if __name__ == '__main__':
                        {'name':'MJD','value':d.mjd,'comment':'Modified Julian date'},
                        {'name':'FIBERID','value':d.fid},
                        {'name':'ORDER','value':d.order,'comment':'Order of the continuum fit'},
-                        {'name':'P0','value':d.p0,'comment':'Order 0 parameter of the continuum fit'},
-                        {'name':'P1','value':d.p1,'comment':'Order 1 parameter of the continuum fit'},
                 ]
 
                 if (args.delta_format=='Pk1D'):

--- a/bin/picca_deltas.py
+++ b/bin/picca_deltas.py
@@ -273,8 +273,8 @@ if __name__ == '__main__':
         print("INFO: Adding optical depth")
         assert args.optical_depth%3==0
         for idxop in range(args.optical_depth//3):
-            tau = args.optical_depth[3*idxop]
-            gamma = args.optical_depth[3*idxop+1]
+            tau = float(args.optical_depth[3*idxop])
+            gamma = float(args.optical_depth[3*idxop+1])
             waveRF = constants.absorber_IGM[args.optical_depth[3*idxop+2]]
             print("INFO: Adding optical depth for tau = {}, gamma = {}, waveRF = {} A".format(tau,gamma,waveRF))
             print(tau,gamma,waveRF)

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -176,7 +176,7 @@ class forest(qso):
             correction = self.correc_ivar(ll)
             iv /= correction
 
-        self.T = None
+        self.Fbar = None
         self.T_dla = None
         self.ll = ll
         self.fl = fl
@@ -267,12 +267,12 @@ class forest(qso):
         if not hasattr(self,'ll'):
             return
 
-        if self.T is None:
-            self.T = sp.ones(self.ll.size)
+        if self.Fbar is None:
+            self.Fbar = sp.ones(self.ll.size)
 
         w = 10.**self.ll/(1.+self.zqso)<=waveRF
         z = 10.**self.ll/waveRF-1.
-        self.T[w] *= sp.exp(-tau*(1.+z[w])**gamma)
+        self.Fbar[w] *= sp.exp(-tau*(1.+z[w])**gamma)
 
         return
 
@@ -318,8 +318,8 @@ class forest(qso):
         except ValueError:
             raise Exception
 
-        if not self.T is None:
-            mc *= self.T
+        if not self.Fbar is None:
+            mc *= self.Fbar
         if not self.T_dla is None:
             mc*=self.T_dla
 

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -254,7 +254,7 @@ class forest(qso):
         for l in mask_RF:
             w &= (self.ll-sp.log10(1.+self.zqso)<l[0]) | (self.ll-sp.log10(1.+self.zqso)>l[1])
 
-        ps = ['iv','ll','fl','T_dla','T','mmef','diff','reso']
+        ps = ['iv','ll','fl','T_dla','Fbar','mmef','diff','reso']
         for p in ps:
             if hasattr(self,p) and (getattr(self,p) is not None):
                 setattr(self,p,getattr(self,p)[w])
@@ -289,7 +289,7 @@ class forest(qso):
             for l in mask:
                 w &= (self.ll-sp.log10(1.+zabs)<l[0]) | (self.ll-sp.log10(1.+zabs)>l[1])
 
-        ps = ['iv','ll','fl','T_dla','T','mmef','diff','reso']
+        ps = ['iv','ll','fl','T_dla','Fbar','mmef','diff','reso']
         for p in ps:
             if hasattr(self,p) and (getattr(self,p) is not None):
                 setattr(self,p,getattr(self,p)[w])
@@ -303,7 +303,7 @@ class forest(qso):
         w = sp.ones(self.ll.size, dtype=bool)
         w &= sp.fabs(1.e4*(self.ll-sp.log10(lambda_absorber)))>forest.absorber_mask
 
-        ps = ['iv','ll','fl','T_dla','T','mmef','diff','reso']
+        ps = ['iv','ll','fl','T_dla','Fbar','mmef','diff','reso']
         for p in ps:
             if hasattr(self,p) and (getattr(self,p) is not None):
                 setattr(self,p,getattr(self,p)[w])

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -368,7 +368,7 @@ class forest(qso):
 
 class delta(qso):
 
-    def __init__(self,thid,ra,dec,zqso,plate,mjd,fid,ll,we,co,de,order,iv,diff,m_SNR,m_reso,m_z,dll,p0=None,p1=None):
+    def __init__(self,thid,ra,dec,zqso,plate,mjd,fid,ll,we,co,de,order,iv,diff,m_SNR,m_reso,m_z,dll):
 
         qso.__init__(self,thid,ra,dec,zqso,plate,mjd,fid)
         self.ll = ll
@@ -382,8 +382,6 @@ class delta(qso):
         self.mean_reso = m_reso
         self.mean_z = m_z
         self.dll = dll
-        self.p0 = p0
-        self.p1 = p1
 
     @classmethod
     def from_forest(cls,f,st,var_lss,eta,fudge,mc=False):
@@ -406,7 +404,7 @@ class delta(qso):
         iv = f.iv/(eta+(eta==0))*(mef**2)
 
         return cls(f.thid,f.ra,f.dec,f.zqso,f.plate,f.mjd,f.fid,ll,we,f.co,de,f.order,
-                   iv,diff,f.mean_SNR,f.mean_reso,f.mean_z,f.dll,f.p0,f.p1)
+                   iv,diff,f.mean_SNR,f.mean_reso,f.mean_z,f.dll)
 
 
     @classmethod

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -270,8 +270,9 @@ class forest(qso):
         if self.T is None:
             self.T = sp.ones(self.ll.size)
 
+        w = 10.**self.ll/(1.+self.zqso)<=waveRF
         z = 10.**self.ll/waveRF-1.
-        self.T *= sp.exp(-tau*(1.+z)**gamma)
+        self.T[w] *= sp.exp(-tau*(1.+z[w])**gamma)
 
         return
 


### PR DESCRIPTION
Add correction of the continuum by the optical depth, fix ticket https://github.com/igmhub/picca/issues/512:
in `picca_delats.py`, simply add `--optical-depth tau gamma line`, e.g.:
```
--optical-depth 5.54e-3 3.182 LYA
```
for the Lya forest or even more lines for the Lyb forest for example:
```
--optical-depth 5.54e-3 3.182 LYA   0.0010529 3.182 LYB   0.0003859013652828086 3.182 LY3   0.0001855334790809328 3.182 LY4   0.00010381915827024538 3.182 LY5
```

Here is what it looks like for the Lya forest:

![example_LYA](https://user-images.githubusercontent.com/3166436/58432572-44c58a80-8070-11e9-8fdd-5b42b2475f44.png)

for the Lyb forest:

![example_LYB](https://user-images.githubusercontent.com/3166436/58432478-d1237d80-806f-11e9-8c19-23f9cb2ae62f.png)