### PR TITLE
ask-for-one-version-numba

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-numpy>=1.16.3
+numpy>=1.16.4
 scipy>=1.2.1
 iminuit>=1.3.6
 healpy>=1.12.9
 fitsio>=1.0.3
-llvmlite>=0.28.0
-numba>=0.43.1
+llvmlite>=0.29.0
+numba==0.43.1
 h5py>=2.9.0
 future>=0.17.1
 setuptools==27.2.0


### PR DESCRIPTION
Require given version of numba since picca is broken with `numba==0.44.0`