### PR TITLE
Combined fit effective redshift

### DIFF
--- a/py/picca/fitter2/effective-bins.py
+++ b/py/picca/fitter2/effective-bins.py
@@ -37,100 +37,101 @@ def derivative(f,x):
     der = (f(x+eps)-f(x))/eps
     return der
 
-def extract_h5file(fname,cor_name):
+def extract_h5file(fname):
+    '''
+
+    '''
+
     f = h5py.File(os.path.expandvars(fname),'r')
+
     free_p = [ el.decode('UTF-8') for el in f['best fit'].attrs['list of free pars'] ]
     fixed_p = [ el.decode('UTF-8') for el in f['best fit'].attrs['list of fixed pars'] ]
-    pars = {}
-    err_pars = {}
-    for i in free_p:
-        pars[i] = f['best fit'].attrs[i][0]
-        err_pars[i] = f['best fit'].attrs[i][1]
-    for i in fixed_p:
-        pars[i] = f['best fit'].attrs[i][0]
-        err_pars[i] = 0.
-    xi = sp.array(f[cor_name]['fit'])
+    pars = { el:f['best fit'].attrs[el][0] for el in free_p }
+    err_pars = { el:f['best fit'].attrs[el][1] for el in free_p }
+    pars.update({ el:f['best fit'].attrs[el][0] for el in fixed_p })
+    err_pars.update({ el:0. for el in fixed_p })
+
     f.close()
 
-    return free_p,fixed_p,pars,err_pars,xi
+    return free_p, fixed_p, pars, err_pars
 
 def extract_data(chi2file,dic_init):
+
+    data = {}
+
     cp = ConfigParser.ConfigParser()
     cp.optionxform=str
     cp.read(os.path.expandvars(chi2file))
-    dic_data = fit_parser.parse_data(os.path.expandvars(cp.get('data sets','ini files')),
-        cp.get('data sets','zeff'),dic_init['fiducial'])
-    data_file = dic_data['data']['filename']
-    f = fitsio.FITS(data_file)
-    cov = f[1]['CO'][:]
-    rp = f[1]['RP'][:]
-    rt = f[1]['RT'][:]
-    z = f[1]['Z'][:]
-    ico = linalg.inv(cov)
+    zeff = cp.get('data sets','zeff')
 
-    head = f[1].read_header()
-    nt = head['NT']
-    np = head['NP']
-    rt_min = 0.
-    rt_max = head['RTMAX']
-    rp_min = head['RPMIN']
-    rp_max = head['RPMAX']
+    for d in cp.get('data sets','ini files').split():
+        dic_data = fit_parser.parse_data(os.path.expandvars(d),zeff,dic_init['fiducial'])
+        name = dic_data['data']['name']
+        data[name] = {}
 
-    r_min = dic_data['cuts']['r-min']
-    r_max = dic_data['cuts']['r-max']
-    f.close()
+        f = fitsio.FITS(dic_data['data']['filename'])
 
-    return ico,rp,rt,np,nt,rp_min,rp_max,rt_min,rt_max,r_min,r_max,z
+        head = f[1].read_header()
+        data[name]['nt'] = head['NT']
+        data[name]['np'] = head['NP']
+        data[name]['rt_min'] = 0.
+        data[name]['rt_max'] = head['RTMAX']
+        data[name]['rp_min'] = head['RPMIN']
+        data[name]['rp_max'] = head['RPMAX']
 
-def apply_mask(dm,ico,z,dic):
-    for d in dic['data sets']['data']:
-        for i in dm:
-            dm_dp[i][~d.mask] = 0.
-        ico[:,~d.mask] = 0.
-        ico[~d.mask,:] = 0.
-        z[~d.mask] = 0.
+        data[name]['r_min'] = dic_data['cuts']['r-min']
+        data[name]['r_max'] = dic_data['cuts']['r-max']
+        f.close()
 
-def xi_mod(pars,dic_init):
+    return data
+
+def apply_mask(data,dm_dp):
+    for k in dm_dp.keys():
+        dm_dp[k][~data.mask] = 0.
+    data.ico = linalg.inv(data.co)
+    data.ico[:,~data.mask] = 0.
+    data.ico[~data.mask,:] = 0.
+    data.z[~data.mask] = 0.
+
+    return
+
+def xi_mod(pars, data, dic_init):
+
     k = dic_init['fiducial']['k']
     pk_lin = dic_init['fiducial']['pk']
     pksb_lin = dic_init['fiducial']['pksb']
-    for d in dic_init['data sets']['data']:
-        pars['SB'] = False
-        xi_best_fit = pars['bao_amp']*d.xi_model(k, pk_lin-pksb_lin, pars)
 
-        pars['SB'] = True
-        snl_par = pars['sigmaNL_par']
-        snl_per = pars['sigmaNL_per']
-        pars['sigmaNL_par'] = 0.
-        pars['sigmaNL_per'] = 0.
-        xi_best_fit += d.xi_model(k, pksb_lin, pars)
+    pars['SB'] = False
+    xi_best_fit = pars['bao_amp']*data.xi_model(k, pk_lin-pksb_lin, pars)
 
-        pars['SB'] = False
-        pars['sigmaNL_par'] = snl_par
-        pars['sigmaNL_per'] = snl_per
+    pars['SB'] = True
+    snl_par = pars['sigmaNL_par']
+    snl_per = pars['sigmaNL_per']
+    pars['sigmaNL_par'] = 0.
+    pars['sigmaNL_per'] = 0.
+    xi_best_fit += data.xi_model(k, pksb_lin, pars)
+
+    pars['SB'] = False
+    pars['sigmaNL_par'] = snl_par
+    pars['sigmaNL_per'] = snl_per
 
     return xi_best_fit
 
-def plot_xi(xi,title=' '):
-    plt.figure()
-    plt.imshow(xi.reshape((np,nt)),origin=0,interpolation='nearest',
-        extent=[rt_min,rt_max,rp_min,rp_max],cmap='seismic',
-        vmin=-max(abs(xi.min()),abs(xi.max())),vmax=max(abs(xi.min()),abs(xi.max())))
-    plt.colorbar()
-    plt.ylabel(r"$r_{\parallel}$",size=20)
-    plt.xlabel(r"$r_{\perp}$",size=20)
-    plt.title(r'$'+title+'$',size = 20)
+def xi_mod_p(x, data, dic_init, pname, pars):
 
-def xi_mod_p(x,pname,pars):
     pars2 = copy.deepcopy(pars)
     pars2[pname] = x
-    return xi_mod(pars2,dic_init)
 
-def compute_dm_dp(freep,pars):
+    return xi_mod(pars2, data=data, dic_init=dic_init)
+
+def compute_dm_dp(data, dic_init, freep, pars):
+
     dm = {}
-    for p in freep :
-        g = functools.partial(xi_mod_p,pname=p,pars=pars)
+    for p in freep:
+        print('Parameter {}'.format(p))
+        g = functools.partial(xi_mod_p, data=data, dic_init=dic_init, pname=p, pars=pars)
         dm[p] = derivative(g,pars[p])
+
     return dm
 
 def compute_M(dm_dp,icov):
@@ -149,6 +150,16 @@ def compute_z0(M,z):
             den += M[i,j]
     return res,den
 
+def plot_xi(xi,data,title=' '):
+    plt.figure()
+    plt.imshow(xi.reshape((data['np'],data['nt'])),origin=0,interpolation='nearest',
+        extent=[data['rt_min'],data['rt_max'],data['rp_min'],data['rp_max']],cmap='seismic',
+        vmin=-max(abs(xi.min()),abs(xi.max())),vmax=max(abs(xi.min()),abs(xi.max())))
+    plt.colorbar()
+    plt.ylabel(r"$r_{\parallel}$",size=20)
+    plt.xlabel(r"$r_{\perp}$",size=20)
+    plt.title(r'$'+title+'$',size = 20)
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     description='Measure the bins contribution to the fitted parameters and  compute their effective redshift')
@@ -156,46 +167,61 @@ if __name__ == '__main__':
     parser.add_argument('--chi2-file', type=str, required=True,
         help = "Path to the config 'chi2.ini' file used in fitter2")
 
-    parser.add_argument('--cor-name', type=str, required=True,
-        help = "Name of the correlation in 'config.ini' to look at")
-
-    parser.add_argument('--params', type=str,default=[], required=False, nargs='*',
+    parser.add_argument('--params', type=str,default=['all'], required=False, nargs='*',
         help="List of the fitted parameters, if 'all' in list compute all")
 
     parser.add_argument('--plot-effective-bins', action='store_true',
         help='Display an image with the bins involved in the fit of each selected parameter')
 
     args = parser.parse_args()
-    chi2_file = args.chi2_file
 
     ### Open files
-    dic_init = fit_parser.parse_chi2(chi2_file)
-    h5_file = dic_init['outfile']
-    free_pars,fixed_pars,best_fit_pars,err_best_fit_pars,xi_best_fit = extract_h5file(h5_file,args.cor_name)
+    dic_init = fit_parser.parse_chi2(args.chi2_file)
+
+    free_pars, fixed_pars, best_fit_pars, err_best_fit_pars = extract_h5file(dic_init['outfile'])
     if 'all' in args.params:
         args.params = free_pars.copy()
     if sp.any(~sp.in1d(args.params,free_pars)):
         print('ERROR: Some parameters are not fitted {}, the list is {}'.format(args.params,free_pars))
         sys.exit(12)
-    ico,rp,rt,np,nt,rp_min,rp_max,rt_min,rt_max,r_min,r_max,z = extract_data(chi2_file,dic_init)
+
+    ### Computing derivatives for each parameter, in each correlation
+    for data in dic_init['data sets']['data']:
+        print('\n data: {}\n'.format(data.name))
+        data.dm_dp = compute_dm_dp(data,dic_init,free_pars,best_fit_pars)
+        apply_mask(data,data.dm_dp)
 
     ### Computation of the effective bins
-    dm_dp = compute_dm_dp(free_pars,best_fit_pars)
-    apply_mask(dm_dp,ico,z,dic_init)
-
-    for p in args.params:
+    print("\n")
+    if False:
+    #for p in args.params:
         print('Parameter {}'.format(p))
-        M = compute_M(dm_dp[p],ico)
-        res,den = compute_z0(M,z)
-        print('<z> = %2.3f/%2.3f = %2.3f'%(res,den,res/den))
-        print('\n')
 
+        res = []
+        den = []
+        for data in dic_init['data sets']['data']:
+            M = compute_M(data.dm_dp[p],data.ico)
+            tres, tden = compute_z0(M,data.z)
+            res += [tres]
+            den += [tden]
+            print('{}, <z> = {}/{} = {}'.format(data.name,tres,tden,tres/tden))
+
+        if len(dic_init['data sets']['data'])>1:
+            res = sp.array(res).sum()
+            den = sp.array(den).sum()
+            print('Combined')
+            print('<z> = {}/{} = {}'.format(res,den,res/den))
+            print('\n')
+
+    ### Plot
     if args.plot_effective_bins:
+        datap = extract_data(args.chi2_file, dic_init)
         for p in args.params:
             lab = '\partial m/ \partial '
             if p in labels:
                 lab += labels[p]
             else:
                 lab += p.replace('_','-')
-            plot_xi(dm_dp[p],lab)
+            for data in dic_init['data sets']['data']:
+                plot_xi(data.dm_dp[p],datap[data.name],data.name.replace('_','-')+'\,'+lab)
         plt.show()

--- a/py/picca/fitter2/effective-bins.py
+++ b/py/picca/fitter2/effective-bins.py
@@ -134,20 +134,13 @@ def compute_dm_dp(data, dic_init, freep, pars):
 
     return dm
 
-def compute_M(dm_dp,icov):
-    M = sp.zeros(icov.shape)
-    for i in range(icov.shape[0]):
-        for j in range(icov.shape[0]):
-            M[i,j] = dm_dp[i] * icov[i,j] * dm_dp[j]
+def compute_M(dm_dp,ico):
+    M = ico*(dm_dp*dm_dp[:,None])
     return M
 
 def compute_z0(M,z):
-    res = 0.
-    den = 0.
-    for i in range(z.shape[0]):
-        for j in range(z.shape[0]):
-            res += M[i,j]*z[i]
-            den += M[i,j]
+    res = (M*z[:,None]).sum()
+    den = M.sum()
     return res,den
 
 def plot_xi(xi,data,title=' '):
@@ -193,9 +186,8 @@ if __name__ == '__main__':
 
     ### Computation of the effective bins
     print("\n")
-    if False:
-    #for p in args.params:
-        print('Parameter {}'.format(p))
+    for p in args.params:
+        print('\n\nParameter {}'.format(p))
 
         res = []
         den = []
@@ -211,7 +203,6 @@ if __name__ == '__main__':
             den = sp.array(den).sum()
             print('Combined')
             print('<z> = {}/{} = {}'.format(res,den,res/den))
-            print('\n')
 
     ### Plot
     if args.plot_effective_bins:

--- a/py/picca/fitter2/effective-bins.py
+++ b/py/picca/fitter2/effective-bins.py
@@ -85,9 +85,9 @@ def extract_data(chi2file,dic_init):
 
     return data
 
-def apply_mask(data,dm_dp):
-    for k in dm_dp.keys():
-        dm_dp[k][~data.mask] = 0.
+def apply_mask(data):
+    for k in data.dm_dp.keys():
+        data.dm_dp[k][~data.mask] = 0.
     data.ico = linalg.inv(data.co)
     data.ico[:,~data.mask] = 0.
     data.ico[~data.mask,:] = 0.
@@ -182,7 +182,7 @@ if __name__ == '__main__':
     for data in dic_init['data sets']['data']:
         print('\n data: {}\n'.format(data.name))
         data.dm_dp = compute_dm_dp(data,dic_init,free_pars,best_fit_pars)
-        apply_mask(data,data.dm_dp)
+        apply_mask(data)
 
     ### Computation of the effective bins
     print("\n")


### PR DESCRIPTION
Combined fit effective redshift, fix ticket https://github.com/igmhub/picca/issues/647

branch:
```
Parameter BB-cf_z_0_10-0-broadband_sky-scale-sky
cf_z_0_10, <z> = 8597432.77084625/3656274.0656583067 = 2.351419126809438

Parameter BB-cf_z_0_10-0-broadband_sky-sigma-sky
cf_z_0_10, <z> = 0.8096047387020991/0.34431278611023847 = 2.351364141449247

Parameter ap
cf_z_0_10, <z> = 1891.4440586448095/808.5082831093425 = 2.3394244662166446

Parameter at
cf_z_0_10, <z> = 992.4750440057763/425.51929176654687 = 2.3323855421113997

Parameter beta_LYA
cf_z_0_10, <z> = 42130.56229123025/18015.46178166452 = 2.3385779838354854

Parameter bias_eta_LYA
cf_z_0_10, <z> = 4316224.430717088/1844180.1970660307 = 2.340456988738908
```

master:
```
Parameter BB-cf_z_0_10-0-broadband_sky-scale-sky
<z> = 8597432.771/3656274.066 = 2.351

Parameter BB-cf_z_0_10-0-broadband_sky-sigma-sky
<z> = 0.810/0.344 = 2.351

Parameter ap
<z> = 1891.444/808.508 = 2.339

Parameter at
<z> = 992.475/425.519 = 2.332

Parameter beta_LYA
<z> = 42130.562/18015.462 = 2.339

Parameter bias_eta_LYA
<z> = 4316224.431/1844180.197 = 2.340
```