### PR TITLE
error message if using other non om cosmology in wick

### DIFF
--- a/bin/picca_wick.py
+++ b/bin/picca_wick.py
@@ -142,6 +142,10 @@ if __name__ == '__main__':
     cf.rej = args.rej
     cf.max_diagram = args.max_diagram
 
+    ### Cosmo
+    if (args.fid_Or!=0.) or (args.fid_Ok!=0.) or (args.fid_wl!=-1.):
+        print("ERROR: Cosmology with other than Omega_m set are not yet implemented")
+        sys.exit()
     cosmo = constants.cosmo(Om=args.fid_Om,Or=args.fid_Or,Ok=args.fid_Ok,wl=args.fid_wl)
 
     ### Read data

--- a/bin/picca_xwick.py
+++ b/bin/picca_xwick.py
@@ -86,6 +86,15 @@ if __name__ == '__main__':
     parser.add_argument('--fid-Om', type=float, default=0.315, required=False,
         help='Omega_matter(z=0) of fiducial LambdaCDM cosmology')
 
+    parser.add_argument('--fid-Or', type=float, default=0., required=False,
+        help='Omega_radiation(z=0) of fiducial LambdaCDM cosmology')
+
+    parser.add_argument('--fid-Ok', type=float, default=0., required=False,
+        help='Omega_k(z=0) of fiducial LambdaCDM cosmology')
+
+    parser.add_argument('--fid-wl', type=float, default=-1., required=False,
+        help='Equation of state of dark energy of fiducial LambdaCDM cosmology')
+
     parser.add_argument('--max-diagram', type=int, default=4, required=False,
         help='Maximum diagram to compute')
 
@@ -130,7 +139,10 @@ if __name__ == '__main__':
     xcf.max_diagram = args.max_diagram
 
     ### Cosmo
-    cosmo = constants.cosmo(args.fid_Om)
+    if (args.fid_Or!=0.) or (args.fid_Ok!=0.) or (args.fid_wl!=-1.):
+        print("ERROR: Cosmology with other than Omega_m set are not yet implemented")
+        sys.exit()
+    cosmo = constants.cosmo(Om=args.fid_Om,Or=args.fid_Or,Ok=args.fid_Ok,wl=args.fid_wl)
 
     ### Read deltas
     dels, ndels, zmin_pix, zmax_pix = io.read_deltas(args.in_dir, args.nside, xcf.lambda_abs, args.z_evol_del, args.z_ref, cosmo=cosmo,nspec=args.nspec)


### PR DESCRIPTION
error message if using other non om cosmology in wick.
Cosmology with other parameters than om are not yet implemented in Wick computation, print an error message and quit if the user tries to do it.