### PR TITLE
add reading confidence levels from file

### DIFF
--- a/tutorials/data/picca_plot_chi2_surface.py
+++ b/tutorials/data/picca_plot_chi2_surface.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
+import os
 import scipy as sp
+import scipy.stats
 import matplotlib.pyplot as plt
 import argparse
 
@@ -34,7 +36,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     color = ['blue','red','green','orange']
-    levels = [2.29, 6.18, 11.82]
 
     assert len(args.chi2scan)==len(args.label)
 
@@ -63,6 +64,17 @@ if __name__ == '__main__':
         first_line = first_line.split()
         fromkeytoindex_bestfitBAO = { el:i for i,el in enumerate(first_line) }
         chi2_bestfitBAO = sp.loadtxt(path.replace('.ap.at.scan.dat','.save.pars'))
+
+        ### Read the convertion from delta-chi2 to sigma
+        if not os.path.isfile(path.replace('.ap.at.scan.dat','.dchi2.to.sigma')):
+            print("WARNING: did not find .dchi2.to.sigma to convert delta-chi2 to sigma, assuming Linear mapping")
+            levels = [ sp.stats.chi2.ppf( sp.stats.chi2.cdf(sigma**2,1), 2) for sigma in range(1,4)]
+        else:
+            with open(path.replace('.ap.at.scan.dat','.dchi2.to.sigma')) as f:
+                for line in f:
+                    line = line.split()
+                    if line[0]=='ap_at':
+                        levels = [float(lev) for lev in line[1:]]
 
         ### Read the fiducial cosmology
         if args.d_over_rd:


### PR DESCRIPTION
For the data, there is a small tutorial script that plots the chi2 scan contours. This PR adds the default feature of reading the mapping from delta-chi2 to sigma from a file that will be added in DR16: `*.dchi2.to.sigma`. If the file is not given the script assumes linearity for the mapping.