### PR TITLE
Redo dr12

### DIFF
--- a/bin/picca_deltas.py
+++ b/bin/picca_deltas.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
         help='Upper limit on quasar redshift from drq')
 
     parser.add_argument('--keep-zero-thid',action='store_true',required=False,
-        help='Do not quasars with THING_ID < 1')
+        help='Do not reject quasars with THING_ID < 1')
 
     parser.add_argument('--keep-bal',action='store_true',required=False,
         help='Do not reject BALs in drq')

--- a/bin/picca_deltas.py
+++ b/bin/picca_deltas.py
@@ -56,6 +56,9 @@ if __name__ == '__main__':
     parser.add_argument('--zqso-max',type=float,default=None,required=False,
         help='Upper limit on quasar redshift from drq')
 
+    parser.add_argument('--keep-zero-thid',action='store_true',required=False,
+        help='Do not quasars with THING_ID < 1')
+
     parser.add_argument('--keep-bal',action='store_true',required=False,
         help='Do not reject BALs in drq')
 
@@ -213,7 +216,8 @@ if __name__ == '__main__':
     data,ndata,healpy_nside,healpy_pix_ordering = io.read_data(os.path.expandvars(args.in_dir), args.drq, args.mode,\
         zmin=args.zqso_min, zmax=args.zqso_max, nspec=args.nspec, log=log,\
         keep_bal=args.keep_bal, bi_max=args.bi_max, order=args.order,\
-        best_obs=args.best_obs, single_exp=args.single_exp, pk1d=args.delta_format )
+        best_obs=args.best_obs, single_exp=args.single_exp, pk1d=args.delta_format,\
+        keep_zero_thid=args.keep_zero_thid)
 
     ### Get the lines to veto
     usr_mask_obs    = None

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -207,8 +207,15 @@ def fill_dmat(l1,l2,r1,r2,rdm1,rdm2,z1,z2,w1,w2,ang,wdm,dm,rpeff,rteff,zeff,weff
     sw1 = w1.sum()
     sw2 = w2.sum()
 
-    ml1 = sp.average(l1,weights=w1)
-    ml2 = sp.average(l2,weights=w2)
+    # if no weights in delta, it shouldn't matter later on
+    if sw1 > 0.:
+        ml1 = sp.average(l1,weights=w1)
+    else:
+        ml1 = sp.average(l1,weights=None)
+    if sw2 > 0.:
+        ml2 = sp.average(l2,weights=w2)
+    else:
+        ml2 = sp.average(l2,weights=None)
 
     dl1 = l1-ml1
     dl2 = l2-ml2
@@ -248,25 +255,51 @@ def fill_dmat(l1,l2,r1,r2,rdm1,rdm2,z1,z2,w1,w2,ang,wdm,dm,rpeff,rteff,zeff,weff
     eta7 = sp.zeros(npm*ntm)
     eta8 = sp.zeros(npm*ntm)
 
-    c = sp.bincount(ij%n1+n1*m_bins,weights=(sp.ones(n1)[:,None]*w2)[w]/sw2)
+    if sw2>0.:
+        c = sp.bincount(ij%n1+n1*m_bins,weights=(sp.ones(n1)[:,None]*w2)[w]/sw2)
+    else:
+        c = sp.bincount(ij%n1+n1*m_bins,weights=None)
     eta1[:len(c)]+=c
-    c = sp.bincount((ij-ij%n1)//n1+n2*m_bins,weights = (w1[:,None]*sp.ones(n2))[w]/sw1)
+    if sw1>0.:
+        c = sp.bincount((ij-ij%n1)//n1+n2*m_bins,weights=(w1[:,None]*sp.ones(n2))[w]/sw1)
+    else:
+        c = sp.bincount((ij-ij%n1)//n1+n2*m_bins,weights=None)
     eta2[:len(c)]+=c
-    c = sp.bincount(m_bins,weights=(w1[:,None]*w2)[w]/sw1/sw2)
+    if sw1*sw2>0.:
+        c = sp.bincount(m_bins,weights=(w1[:,None]*w2)[w]/sw1/sw2)
+    else:
+        c = sp.bincount(m_bins,weights=None)
     eta5[:len(c)]+=c
 
     if order2==1:
-        c = sp.bincount(ij%n1+n1*m_bins,weights=(sp.ones(n1)[:,None]*w2*dl2)[w]/slw2)
+        if slw2>0.:
+            c = sp.bincount(ij%n1+n1*m_bins,weights=(sp.ones(n1)[:,None]*w2*dl2)[w]/slw2)
+        else:
+            c = sp.bincount(ij%n1+n1*m_bins,weights=None)
         eta3[:len(c)]+=c
-        c = sp.bincount(m_bins,weights=(w1[:,None]*(w2*dl2))[w]/sw1/slw2)
+        if slw2*sw1>0.:
+            c = sp.bincount(m_bins,weights=(w1[:,None]*(w2*dl2))[w]/sw1/slw2)
+        else:
+            c = sp.bincount(m_bins,weights=None)
         eta6[:len(c)]+=c
+
     if order1==1:
-        c = sp.bincount((ij-ij%n1)//n1+n2*m_bins,weights = ((w1*dl1)[:,None]*sp.ones(n2))[w]/slw1)
+        if slw1>0.:
+            c = sp.bincount((ij-ij%n1)//n1+n2*m_bins,weights=((w1*dl1)[:,None]*sp.ones(n2))[w]/slw1)
+        else:
+            c = sp.bincount((ij-ij%n1)//n1+n2*m_bins,weights=None)
         eta4[:len(c)]+=c
-        c = sp.bincount(m_bins,weights=((w1*dl1)[:,None]*w2)[w]/slw1/sw2)
+        if slw1*sw2>0.:
+            c = sp.bincount(m_bins,weights=((w1*dl1)[:,None]*w2)[w]/slw1/sw2)
+        else:
+            c = sp.bincount(m_bins,weights=None)
         eta7[:len(c)]+=c
+
         if order2==1:
-            c = sp.bincount(m_bins,weights=((w1*dl1)[:,None]*(w2*dl2))[w]/slw1/slw2)
+            if slw1*slw2>0.:
+                c = sp.bincount(m_bins,weights=((w1*dl1)[:,None]*(w2*dl2))[w]/slw1/slw2)
+            else:
+                c = sp.bincount(m_bins,weights=None)
             eta8[:len(c)]+=c
 
     ubb = sp.unique(m_bins)

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -531,13 +531,18 @@ class delta(qso):
 
 
     def project(self):
-        mde = sp.average(self.de,weights=self.we)
-        res=0
-        if (self.order==1) and self.de.shape[0] > 1:
-            mll = sp.average(self.ll,weights=self.we)
-            mld = sp.sum(self.we*self.de*(self.ll-mll))/sp.sum(self.we*(self.ll-mll)**2)
-            res = mld * (self.ll-mll)
-        elif self.order==1:
-            res = self.de
-
-        self.de -= mde + res
+        # check that the sum of weights is non-zero (sp.average would crash)
+        sum_we=sp.sum(self.we)
+        if sum_we>0:
+            mde = sp.average(self.de,weights=self.we)
+            res=0
+            if (self.order==1) and self.de.shape[0] > 1:
+                mll = sp.average(self.ll,weights=self.we)
+                mld = sp.sum(self.we*self.de*(self.ll-mll))/sp.sum(self.we*(self.ll-mll)**2)
+                res = mld * (self.ll-mll)
+            elif self.order==1:
+                res = self.de
+            self.de -= mde + res
+        else:
+            # this should be rare enough that we can print all cases for now
+            print('skip skewer {} with {} weight'.format(self.thid,sum_we))

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -77,7 +77,7 @@ def read_absorbers(file_absorbers):
 
     return absorbers
 
-def read_drq(drq,zmin,zmax,keep_bal,bi_max=None):
+def read_drq(drq,zmin,zmax,keep_bal,bi_max=None,keep_zero_thid=False):
     h = fitsio.FITS(drq)
 
     ## Redshift
@@ -99,8 +99,9 @@ def read_drq(drq,zmin,zmax,keep_bal,bi_max=None):
     print('')
     w = sp.ones(ra.size,dtype=bool)
     print(" start               : nb object in cat = {}".format(w.sum()) )
-    w &= thid>0
-    print(" and thid>0          : nb object in cat = {}".format(w.sum()) )
+    if not keep_zero_thid:
+        w &= thid>0
+        print(" and thid>0          : nb object in cat = {}".format(w.sum()) )
     w &= ra!=dec
     print(" and ra!=dec         : nb object in cat = {}".format(w.sum()) )
     w &= ra!=0.
@@ -159,10 +160,10 @@ def read_dust_map(drq, Rv = 3.793):
 target_mobj = 500
 nside_min = 8
 
-def read_data(in_dir,drq,mode,zmin = 2.1,zmax = 3.5,nspec=None,log=None,keep_bal=False,bi_max=None,order=1, best_obs=False, single_exp=False, pk1d=None):
+def read_data(in_dir,drq,mode,zmin = 2.1,zmax = 3.5,nspec=None,log=None,keep_bal=False,bi_max=None,order=1, best_obs=False, single_exp=False, pk1d=None,keep_zero_thid=False):
 
     print("mode: "+mode)
-    ra,dec,zqso,thid,plate,mjd,fid = read_drq(drq,zmin,zmax,keep_bal,bi_max=bi_max)
+    ra,dec,zqso,thid,plate,mjd,fid = read_drq(drq,zmin,zmax,keep_bal,bi_max=bi_max,keep_zero_thid=keep_zero_thid)
 
     if nspec != None:
         ## choose them in a small number of pixels
@@ -857,9 +858,9 @@ def read_deltas(indir,nside,lambda_abs,alpha,zref,cosmo,nspec=None,no_project=Fa
     return data,ndata,zmin,zmax
 
 
-def read_objects(drq,nside,zmin,zmax,alpha,zref,cosmo,keep_bal=True):
+def read_objects(drq,nside,zmin,zmax,alpha,zref,cosmo,keep_bal=True,keep_zero_thid=False):
     objs = {}
-    ra,dec,zqso,thid,plate,mjd,fid = read_drq(drq,zmin,zmax,keep_bal=True)
+    ra,dec,zqso,thid,plate,mjd,fid = read_drq(drq,zmin,zmax,keep_bal=keep_bal,keep_zero_thid=keep_zero_thid)
     phi = ra
     th = sp.pi/2.-dec
     pix = healpy.ang2pix(nside,th,phi)

--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -247,9 +247,26 @@ def eBOSS_convert_DLA(inPath,drq,outPath,drqzkey='Z'):
     zqso = h[1][drqzkey][:]
     h.close()
     fromThingid2idx = { el:i for i,el in enumerate(thid) }
-    cat['RA'] = sp.array([ ra[fromThingid2idx[el]] for el in cat['THING_ID'] ])
-    cat['DEC'] = sp.array([ dec[fromThingid2idx[el]] for el in cat['THING_ID'] ])
-    cat['ZQSO'] = sp.array([ zqso[fromThingid2idx[el]] for el in cat['THING_ID'] ])
+    # collect information from the quasar catalog (if can find entry)
+    cat_ra=[]
+    cat_dec=[]
+    cat_zqso=[]
+    for el in cat['THING_ID']:
+        if el in fromThingid2idx:
+            idx=fromThingid2idx[el]
+            cat_ra.append(ra[idx])
+            cat_dec.append(dec[idx])
+            cat_zqso.append(zqso[idx])
+        else:
+            # these will be removed later on
+            print('could not find quasar with THING_ID =',el)
+            cat_ra.append(0.0)
+            cat_dec.append(0.0)
+            cat_zqso.append(0.0)
+
+    cat['RA'] = sp.array(cat_ra)
+    cat['DEC'] = sp.array(cat_dec)
+    cat['ZQSO'] = sp.array(cat_zqso)
 
     w = cat['RA']!=cat['DEC']
     print('INFO: Removed {} DLA, because RA==DEC'.format((cat['RA']==cat['DEC']).sum()))


### PR DESCRIPTION
I've done a couple of minor changes to be able to redo DR12 and DR14 analyses:
 - add option to keep objects with non-positive THING_ID, since this was done in du Mas des Bourboux et al. (2017).
 - ignore DLAs in DLA catalog if there is no quasar with same THING_ID in quasar catalog (19 objects in one of the DR14 DLA catalogs are not in the DR14 quasar catalog).