### PR TITLE
Forecast

### DIFF
--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -224,7 +224,7 @@ class chi2:
             d.co = s*d.co
             d.ico = d.ico/s
             # no need to compute Cholesky when computing forecast
-            if not self.forecast:
+            if not self.forecast_mc:
                 d.cho = cholesky(d.co)
 
         self.fiducial_values = dict(self.best_fit.values).copy()

--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -48,7 +48,7 @@ class chi2:
             if 'forecast' in dic_init['fast mc']:
                 self.forecast_mc = dic_init['fast mc']['forecast']
                 if self.nfast_mc is not 1:
-                    raise valueError('Why forecast more than once?')
+                    sys.exit('ERROR: Why forecast more than once?')
             else:
                 self.forecast_mc = False
 

--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -223,7 +223,9 @@ class chi2:
         for d, s in zip(self.data, self.scalefast_mc):
             d.co = s*d.co
             d.ico = d.ico/s
-            d.cho = cholesky(d.co)
+            # no need to compute Cholesky when computing forecast
+            if not self.forecast:
+                d.cho = cholesky(d.co)
 
         self.fiducial_values = dict(self.best_fit.values).copy()
         for p in self.fidfast_mc:

--- a/py/picca/fitter2/chi2.py
+++ b/py/picca/fitter2/chi2.py
@@ -255,10 +255,10 @@ class chi2:
             for d in self.data:
                 # if computing forecast, do not add randomness
                 if self.forecast_mc:
-                    g = sp.zeros_like(d.da)
+                    d.da = d.fiducial_model
                 else:
                     g = sp.random.randn(len(d.da))
-                d.da = d.cho.dot(g) + d.fiducial_model
+                    d.da = d.cho.dot(g) + d.fiducial_model
                 self.fast_mc_data[d.name+'_'+str(it)] = d.da
                 d.da_cut = d.da[d.mask]
 

--- a/py/picca/fitter2/parser.py
+++ b/py/picca/fitter2/parser.py
@@ -66,8 +66,10 @@ def parse_chi2(filename):
         dic_init['fast mc']['fiducial']['values'] = {}
         dic_init['fast mc']['fiducial']['fix'] = {}
         for item, value in cp.items('fast mc'):
-            if item=='niterations' or item=='seed':
+            if item in ['niterations','seed']:
                 dic_init['fast mc'][item] = int(value)
+            elif item=='forecast':
+                dic_init['fast mc'][item] = bool(value)
             elif item=='covscaling':
                 value = value.split()
                 dic_init['fast mc'][item] = sp.array(value).astype(float)


### PR DESCRIPTION
This short PR adds a feature in the fitter to compute something very similar to the Fisher forecasts. It runs through the FastMC code, but it does not add randomness. This was used to generate Fig 14 of the eBOSS DR16 paper, and I think it will be very useful in DESI as well, to test the impact of different survey strategies BAO uncertainties, without needing to generate multiple FastMC to compute an average error. 