### PR TITLE
fix python2 incompatibility for iminuit

### DIFF
--- a/requirements-python2.txt
+++ b/requirements-python2.txt
@@ -1,6 +1,6 @@
 numpy>=1.16.6
 scipy>=1.2.3
-iminuit==1.4.0
+iminuit==1.3.10
 healpy>=1.13.0
 fitsio==1.0.5
 llvmlite==0.31.0

--- a/requirements-python2.txt
+++ b/requirements-python2.txt
@@ -7,4 +7,4 @@ llvmlite==0.31.0
 numba>=0.47.0
 h5py>=2.10.0
 future>=0.18.2
-setuptools>=44.1.0
+setuptools>=44.1.1

--- a/requirements-python2.txt
+++ b/requirements-python2.txt
@@ -1,6 +1,6 @@
 numpy>=1.16.6
 scipy>=1.2.3
-iminuit>=1.3.10
+iminuit==1.4.0
 healpy>=1.13.0
 fitsio==1.0.5
 llvmlite==0.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-numpy>=1.18.4
-scipy>=1.4.1
-iminuit>=1.3.10
+numpy>=1.19.0
+scipy>=1.5.0
+iminuit>=1.4.5
 healpy>=1.13.0
 fitsio==1.0.5
-llvmlite>=0.32.1
-numba>=0.49.1
+llvmlite>=0.33.0
+numba>=0.50.1
 h5py>=2.10.0
 future>=0.18.2
-setuptools>=46.3.0
+setuptools>=47.3.1


### PR DESCRIPTION
requires the latest version compatible with python2 for iminuit.
Update other packages to latest version just for clarity.
Fix failing tests for python2
```
iminuit==1.3.10
```