### PR TITLE
Travis fix

### DIFF
--- a/bin/picca_co.py
+++ b/bin/picca_co.py
@@ -321,7 +321,7 @@ def main():
     units = ['h^-1 Mpc', 'h^-1 Mpc', '', '']
     results.write([r_par, r_trans, z, num_pairs],
                   names=['RP', 'RT', 'Z', 'NB'],
-                  headerer=header,
+                  header=header,
                   comment=comment,
                   units=units,
                   extname='ATTRI')

--- a/bin/picca_export_cross_covariance.py
+++ b/bin/picca_export_cross_covariance.py
@@ -44,8 +44,8 @@ if __name__ == '__main__':
         hdul = fitsio.FITS(filename)
         header = hdul[1].read_header()
         nside = header['NSIDE']
-        head = hdul[2].read_header()
-        healpix_scheme = head['HLPXSCHM']
+        header2 = hdul[2].read_header()
+        healpix_scheme = header2['HLPXSCHM']
         xi = np.array(hdul[2]['DA'][:])
         weights = np.array(hdul[2]['WE'][:])
         healpix_list = np.array(hdul[2]['HEALPID'][:])

--- a/bin/picca_export_cross_covariance.py
+++ b/bin/picca_export_cross_covariance.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
         header = hdul[1].read_header()
         nside = header['NSIDE']
         head = hdul[2].read_header()
-        healpix_scheme = header['HLPXSCHM']
+        healpix_scheme = head['HLPXSCHM']
         xi = np.array(hdul[2]['DA'][:])
         weights = np.array(hdul[2]['WE'][:])
         healpix_list = np.array(hdul[2]['HEALPID'][:])

--- a/py/picca/test/test_cor.py
+++ b/py/picca/test/test_cor.py
@@ -833,7 +833,8 @@ class TestCor(unittest.TestCase):
         cmd += " --nt 15"
         cmd += " --nproc 1"
         cmd += " --type-corr DD"
-        subprocess.call(cmd, shell=True)
+        returncode=subprocess.call(cmd, shell=True)
+        self.assertEqual(returncode,0,"picca_co did not finish on DD")
         ### Send
         cmd  = " picca_co.py"
         cmd += " --drq "    + self._branchFiles+"/Products/random.fits"
@@ -845,7 +846,8 @@ class TestCor(unittest.TestCase):
         cmd += " --nt 15"
         cmd += " --nproc 1"
         cmd += " --type-corr RR"
-        subprocess.call(cmd, shell=True)
+        returncode=subprocess.call(cmd, shell=True)
+        self.assertEqual(returncode,0,"picca_co did not finish on RR")
         ### Send
         cmd  = " picca_co.py"
         cmd += " --drq "    + self._branchFiles+"/Products/cat.fits"
@@ -858,8 +860,9 @@ class TestCor(unittest.TestCase):
         cmd += " --nt 15"
         cmd += " --nproc 1"
         cmd += " --type-corr DR"
-        subprocess.call(cmd, shell=True)
-        ### Send
+        returncode=subprocess.call(cmd, shell=True)
+        self.assertEqual(returncode,0,"picca_co did not finish on DR")
+                ### Send
         cmd  = " picca_co.py"
         cmd += " --drq "    + self._branchFiles+"/Products/random.fits"
         cmd += " --drq2 "   + self._branchFiles+"/Products/cat.fits"
@@ -871,7 +874,9 @@ class TestCor(unittest.TestCase):
         cmd += " --nt 15"
         cmd += " --nproc 1"
         cmd += " --type-corr RD"
-        subprocess.call(cmd, shell=True)
+        returncode=subprocess.call(cmd, shell=True)
+        self.assertEqual(returncode,0,"picca_co did not finish on RD")
+
 
         ### Test
         if self._test:
@@ -904,7 +909,7 @@ class TestCor(unittest.TestCase):
         cmd += " --out " + self._branchFiles+"/Products/Correlations/exported_co.fits.gz"
         cmd += " --get-cov-from-poisson"
         returncode=subprocess.call(cmd, shell=True)
-        self.assertEqual(returncode,0,"export_co did not finish")
+        self.assertEqual(returncode,0,"picca_export_co did not finish")
 
         return
     def send_fitter2(self):

--- a/py/picca/test/test_cor.py
+++ b/py/picca/test/test_cor.py
@@ -585,8 +585,8 @@ class TestCor(unittest.TestCase):
         cmd += " --data " + self._branchFiles+"/Products/Correlations/cf.fits.gz"
         cmd += " --dmat " + self._branchFiles+"/Products/Correlations/dmat.fits.gz"
         cmd += " --out "  + self._branchFiles+"/Products/Correlations/exported_cf.fits.gz"
-        subprocess.call(cmd, shell=True)
-
+        returncode=subprocess.call(cmd, shell=True)
+        self.assertEqual(returncode,0,"export_cf did not finish")
         return
     def send_cf_cross(self):
 
@@ -675,7 +675,9 @@ class TestCor(unittest.TestCase):
         cmd += " --data " + self._branchFiles+"/Products/Correlations/cf_cross.fits.gz"
         cmd += " --dmat " + self._branchFiles+"/Products/Correlations/dmat_cross.fits.gz"
         cmd += " --out "  + self._branchFiles+"/Products/Correlations/exported_cf_cross.fits.gz"
-        subprocess.call(cmd, shell=True)
+        returncode = subprocess.call(cmd, shell=True)
+        self.assertEqual(returncode,0,"export_cf_cross did not finish")
+
 
         return
     def send_xcf_angl(self):
@@ -801,7 +803,8 @@ class TestCor(unittest.TestCase):
         cmd += " --data " + self._branchFiles+"/Products/Correlations/xcf.fits.gz"
         cmd += " --dmat " + self._branchFiles+"/Products/Correlations/xdmat.fits.gz"
         cmd += " --out "  + self._branchFiles+"/Products/Correlations/exported_xcf.fits.gz"
-        subprocess.call(cmd, shell=True)
+        returncode=subprocess.call(cmd, shell=True)
+        self.assertEqual(returncode,0,"export_xcf did not finish")
 
         return
     def send_export_cross_covariance_cf_xcf(self):
@@ -812,7 +815,8 @@ class TestCor(unittest.TestCase):
         cmd += " --data1 " + self._branchFiles+"/Products/Correlations/cf.fits.gz"
         cmd += " --data2 " + self._branchFiles+"/Products/Correlations/xcf.fits.gz"
         cmd += " --out "   + self._branchFiles+"/Products/Correlations/exported_cross_covariance_cf_xcf.fits.gz"
-        subprocess.call(cmd, shell=True)
+        returncode=subprocess.call(cmd, shell=True)
+        self.assertEqual(returncode,0,"export_cross_covariance_cf_xcf did not finish")
 
         return
     def send_co(self):
@@ -899,7 +903,8 @@ class TestCor(unittest.TestCase):
         cmd += " --RD-file " + self._branchFiles+"/Products/Correlations/Co_Random/co_RD.fits.gz"
         cmd += " --out " + self._branchFiles+"/Products/Correlations/exported_co.fits.gz"
         cmd += " --get-cov-from-poisson"
-        subprocess.call(cmd, shell=True)
+        returncode=subprocess.call(cmd, shell=True)
+        self.assertEqual(returncode,0,"export_co did not finish")
 
         return
     def send_fitter2(self):


### PR DESCRIPTION
This fixes part of Issue #725

One of the tracebacks shown by travis on current master is fixed. The other one ('picca_export_co') I didn't yet find the reason for. If I'm running the test on files in `picca/py/picca/test/data` everything works smoothly, but when running the test it fails, so there might be some difference between saved outputs in the directory and when calling the routines in the test.

I also changed the travis test so that routines which do not compare fits or hdf5 files (i.e. all `picca_export_*` and `picca_co`) will fail the test in cases where the code does not complete. The current master does not check for completion in these cases and thus returned a pass in travis without actually passing everything.