### PR TITLE
function __add__ from Forest renamed to coadd

### DIFF
--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -585,8 +585,8 @@ class Forest(QSO):
         self.p1 = None
         self.bad_cont = None
 
-    def __add__(self, other):
-        """Adds the information of another forest.
+    def coadd(self, other):
+        """Coadds the information of another forest.
 
         Forests are coadded by using inverse variance weighting.
 

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -679,19 +679,20 @@ def read_from_spec(in_dir,
                                 exposures_diff=exposures_diff,
                                 reso=reso)
             else:
-                deltas += Forest(log_lambda,
-                                 flux,
-                                 ivar,
-                                 metadata.thingid,
-                                 metadata.ra,
-                                 metadata.dec,
-                                 metadata.z_qso,
-                                 metadata.plate,
-                                 metadata.mjd,
-                                 metadata.fiberid,
-                                 order,
-                                 exposures_diff=exposures_diff,
-                                 reso=reso)
+                deltas.coadd(
+                    Forest(log_lambda,
+                           flux,
+                           ivar,
+                           metadata.thingid,
+                           metadata.ra,
+                           metadata.dec,
+                           metadata.z_qso,
+                           metadata.plate,
+                           metadata.mjd,
+                           metadata.fiberid,
+                           order,
+                           exposures_diff=exposures_diff,
+                           reso=reso))
             hdul.close()
         if deltas is not None:
             pix_data.append(deltas)
@@ -1289,9 +1290,10 @@ def read_from_desi(nside,
                                dec[w_t][0], z_table[t], p, m, f, order,
                                exposures_diff, reso_in_km_per_s))
                 else:
-                    forest += Forest(spec['log_lambda'], flux, ivar, t,
-                                     ra[w_t][0], dec[w_t][0], z_table[t], p, m,
-                                     f, order, exposures_diff, reso_in_km_per_s)
+                    forest.coadd(
+                        Forest(spec['log_lambda'], flux, ivar, t, ra[w_t][0],
+                               dec[w_t][0], z_table[t], p, m, f, order,
+                               exposures_diff, reso_in_km_per_s))
 
             pix = healpixs[w_t][0]
             if pix not in data:


### PR DESCRIPTION
I modified the function name and Travis seems to be fine with it so this might be a bit tricky to revise. After that, I looked at the places where two Forest instances were summed and replaced the sum by the coadd function. Note that I only found this to happen in the reading functions