### PR TITLE
modified travis python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-    - "3.6"
+    - "3.8"
 
 install:
     - pip install -r requirements.txt


### PR DESCRIPTION
When I run picca automatic tests (on branch master, updated) at NERSC and on my local laptop the automatic tests fail, but Travis says it is fine. It seems that the problem comes from the way pool is interacting with the classes. I checked that before line `data_fit_cont = pool.map(cont_fit, sorted_data)`, the variable `Forest.log_lambda_max_rest_frame` is correctly valued, but after the command it is set to `None`. 

I add this pull request to check if the problem lies with the python version (I'm using version 3.8, whereas travis was set on version 3.7), or has something to do with the OS