### PR TITLE
fixed functions fill_neighs

### DIFF
--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -84,7 +84,7 @@ def fill_neighs(healpixs):
                 nside, [delta.x_cart, delta.y_cart, delta.z_cart],
                 ang_max,
                 inclusive=True)
-            if x_correlation:
+            if data2 is not None:
                 healpix_neighbours = [
                     other_healpix for other_healpix in healpix_neighbours
                     if other_healpix in data2

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -107,7 +107,7 @@ def fill_neighs(healpixs):
             ang = delta.get_angle_between(neighbours)
             w = ang < ang_max
             neighbours = np.array(neighbours)[w]
-            if x_correlation:
+            if data2 is not None:
                 delta.neighbours = [
                     other_delta for other_delta in neighbours
                     if ((other_delta.z[-1] + delta.z[-1]) / 2. >= z_cut_min and

--- a/py/picca/co.py
+++ b/py/picca/co.py
@@ -46,7 +46,7 @@ def fill_neighs(healpixs):
                 nside, [obj1.x_cart, obj1.y_cart, obj1.z_cart],
                 ang_max,
                 inclusive=True)
-            if x_correlation:
+            if objs2 is not None:
                 healpix_neighbours = [
                     healpix for healpix in healpix_neighbours
                     if healpix in objs2

--- a/py/picca/test/test_cor.py
+++ b/py/picca/test/test_cor.py
@@ -439,9 +439,17 @@ class TestCor(unittest.TestCase):
                                  "{}".format(nameRun))
             for item in atts1:
                 nequal = True
-                if isinstance(atts1[item], np.ndarray):
-                    nequal = np.logical_not(
-                        np.array_equal(atts1[item], atts2[item]))
+                if isinstance(atts1[item], np.ndarray): #the dtype check is needed for h5py version 3
+                    dtype1=atts1[item].dtype
+                    dtype2=atts2[item].dtype
+                    if dtype1==dtype2:
+                        nequal = np.logical_not(
+                            np.array_equal(atts1[item], atts2[item]))
+                    else:
+                        userprint(f"Note that the test file has different dtype for attribute {item}")
+                        nequal = np.logical_not(np.array_equal(atts1[item].astype(atts2[item].dtype), atts2[item]))
+                        if nequal:
+                            nequal = np.logical_not(np.array_equal(atts2[item].astype(atts1[item].dtype), atts1[item]))
                 else:
                     nequal = atts1[item] != atts2[item]
                 if nequal:


### PR DESCRIPTION
I have fixed the problems in issue #753 by changing the comparison made in the function fill_neighs of `picca/cf.py`. Now it does not check for the flag `x_correlation` when deciding to use the second set of deltas to compute the neighbours. Instead, it checks for the presence of the second set.

I also discovered that the same bug was occuring in `picca/co.py` so I also fixed it as well.