### PR TITLE
Fix latest fitsio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python:
     - "3.8.3"
 
+before_install:
+  - sudo apt-get -y install libbz2-dev
+
 install:
     - pip install -r requirements.txt
     - python setup.py install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-numpy>=1.19.0
-scipy>=1.5.2
+numpy>=1.19.4
+scipy>=1.5.4
 iminuit>=1.5.2
 healpy>=1.14.0
-fitsio==1.0.5
-llvmlite>=0.33.0
-numba>=0.50.1
-h5py>=2.10.0
+fitsio>=1.1.3
+llvmlite>=0.34.0
+numba>=0.51.2
+h5py>=3.1.0
 future>=0.18.2
-setuptools>=49.2.0
+setuptools>=50.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.19.4
 scipy>=1.5.4
-iminuit>=1.5.2
+iminuit>=1.4.9
 healpy>=1.14.0
 fitsio>=1.1.3
 llvmlite>=0.34.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.19.4
 scipy>=1.5.4
-iminuit>=1.4.9
+iminuit>=1.5.2
 healpy>=1.14.0
 fitsio>=1.1.3
 llvmlite>=0.34.0


### PR DESCRIPTION
This PR allows to use the latest fitsio, by adding `sudo apt-get -y install libbz2-dev` to the travis installation.
This allows to be up to date with latests fixes of dependencies.