### PR TITLE
Changed zcat default downsampling to None

### DIFF
--- a/py/picca/converters.py
+++ b/py/picca/converters.py
@@ -343,7 +343,7 @@ def desi_from_ztarget_to_drq(in_path,
                     cat[key] = cat[key][w]
                 userprint((" and downsampling : nb object in cat = {}, nb z > "
                        "{} = {}").format(cat['RA'].size, downsampling_z_cut,
-                                        (cat["Z"] > downsampling_z_cut).sum()))
+                                        z_cut_num))
             else:
                 userprint(("WARNING:: Trying to downsample, when nb QSOs with "
                            "z > {} = {} and downsampling = {}").format

--- a/py/picca/converters.py
+++ b/py/picca/converters.py
@@ -332,17 +332,22 @@ def desi_from_ztarget_to_drq(in_path,
                        "nb downsampling = {}").format(cat['RA'].size,
                                                       downsampling_num))
         else:
-            select_fraction = (downsampling_num /
-                               (cat['Z'] > downsampling_z_cut).sum())
-            np.random.seed(0)
-            w = np.random.choice(np.arange(cat['RA'].size),
+            z_cut_num = (cat['Z'] > downsampling_z_cut).sum()
+            select_fraction = (downsampling_num / z_cut_num)
+            if select_fraction < 1.0:
+                np.random.seed(0)
+                w = np.random.choice(np.arange(cat['RA'].size),
                                  size=int(cat['RA'].size * select_fraction),
                                  replace=False)
-            for key in cat:
-                cat[key] = cat[key][w]
-            userprint((" and donsampling     : nb object in cat = {}, nb z > "
+                for key in cat:
+                    cat[key] = cat[key][w]
+                userprint((" and downsampling : nb object in cat = {}, nb z > "
                        "{} = {}").format(cat['RA'].size, downsampling_z_cut,
-                                         (cat["Z"] > downsampling_z_cut).sum()))
+                                        (cat["Z"] > downsampling_z_cut).sum()))
+            else:
+                userprint(("WARNING:: Trying to downsample, when nb QSOs with "
+                           "z > {} = {} and downsampling = {}").format
+                           (downsampling_z_cut, z_cut_num, downsampling_num))
 
     # sort by THING_ID
     w = np.argsort(cat['THING_ID'])

--- a/tutorials/desi/picca_convert_zcat.py
+++ b/tutorials/desi/picca_convert_zcat.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     parser.add_argument('--downsampling-z-cut', type = float, default = 2.1, required = False,
             help = "Minimum redshift to downsample the data, if 'None' no downsampling")
 
-    parser.add_argument('--downsampling-nb', type = int, default = None, required = False,
+    parser.add_argument('--downsampling-nb', type = int, default = 700000, required = False,
             help = "Target number of object above redshift downsampling-z-cut, if 'None' no downsampling")
 
     args = parser.parse_args()

--- a/tutorials/desi/picca_convert_zcat.py
+++ b/tutorials/desi/picca_convert_zcat.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     parser.add_argument('--downsampling-z-cut', type = float, default = 2.1, required = False,
             help = "Minimum redshift to downsample the data, if 'None' no downsampling")
 
-    parser.add_argument('--downsampling-nb', type = int, default = 700000, required = False,
+    parser.add_argument('--downsampling-nb', type = int, default = None, required = False,
             help = "Target number of object above redshift downsampling-z-cut, if 'None' no downsampling")
 
     args = parser.parse_args()


### PR DESCRIPTION
I changed the default argument for downsampling-nb in tutorials/desi/picca_convert_zcat.py to None, as it was crashing if the mocks had less than the default value of 700,000.