### PR TITLE
change io to use spectra from deep by default

### DIFF
--- a/bin/picca_deltas.py
+++ b/bin/picca_deltas.py
@@ -404,6 +404,19 @@ def main():
                         required=False,
                         help=('Name for table containing forests metadata'))
 
+    parser.add_argument('--use-single-nights',
+                        action='store_true',
+                        default=False,
+                        required=False,
+                        help=('Use individual night for input spectra (DESI SV)'))
+
+    parser.add_argument('--use-all',
+                        action='store_true',
+                        default=False,
+                        required=False,
+                        help=('Use all dir for input spectra (DESI SV)'))
+                        
+
     t0 = time.time()
 
     args = parser.parse_args()
@@ -501,7 +514,9 @@ def main():
                                          best_obs=args.best_obs,
                                          single_exp=args.single_exp,
                                          pk1d=args.delta_format,
-                                         spall=args.spall)
+                                         spall=args.spall,
+                                         useall=args.use_all,
+                                         usesinglenights=args.use_single_nights)
 
     #-- Add order info
     for pix in data:

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1083,6 +1083,7 @@ def read_from_minisv_desi(in_dir, catalog, pk1d=None, usesinglenights=False, use
             f"{entry['PETAL_LOC']}-{entry['TILEID']}-{entry['NIGHT']}"
             for entry in catalog
         ]
+        #this uniqueness check is to ensure each petal/tile/night combination only appears once in the filelist
         petal_tile_night_unique = np.unique(petal_tile_night)
     
         filenames = []
@@ -1090,6 +1091,7 @@ def read_from_minisv_desi(in_dir, catalog, pk1d=None, usesinglenights=False, use
           for ptn in petal_tile_night_unique:
             if ptn in os.path.basename(f_in):
                 filenames.append(f_in)
+                break
     else:
         if useall:
             files_in = glob.glob(os.path.join(in_dir, "**/all/**/coadd-*.fits"),
@@ -1101,12 +1103,14 @@ def read_from_minisv_desi(in_dir, catalog, pk1d=None, usesinglenights=False, use
             f"{entry['PETAL_LOC']}-{entry['TILEID']}"
             for entry in catalog
         ]
+        #this uniqueness check is to ensure each petal/tile combination only appears once in the filelist
         petal_tile_unique = np.unique(petal_tile)
         filenames = []
         for f_in in files_in:
           for pt in petal_tile_unique:
             if pt in os.path.basename(f_in):
                 filenames.append(f_in)
+                break
 
         
     #filenames = []

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -262,7 +262,9 @@ def read_data(in_dir,
               best_obs=False,
               single_exp=False,
               pk1d=None,
-              spall=None):
+              spall=None,
+              useall=False,
+              usesinglenights=False):
     """Reads the spectra and formats its data as Forest instances.
 
     Args:
@@ -299,6 +301,11 @@ def read_data(in_dir,
             Format for Pk 1D: Pk1D
         spall: str - default: None
             Path to the spAll file required for multiple observations
+        useall: bool - default: False
+            In case of DESI SV readin use the all directory
+        usesinglenights: bool - default: False
+            In case of DESI SV readin use only nights specified within the cat
+        
 
     Returns:
         The following variables:
@@ -413,7 +420,7 @@ def read_data(in_dir,
 
     elif mode == "desiminisv":
         nside = 8
-        data, num_data = read_from_minisv_desi(in_dir, catalog, pk1d=pk1d)
+        data, num_data = read_from_minisv_desi(in_dir, catalog, pk1d=pk1d, useall=useall, usesinglenights=usesinglenights)
     else:
         userprint("I don't know mode: {}".format(mode))
         sys.exit(1)
@@ -1050,7 +1057,7 @@ def read_from_desi(in_dir, catalog, pk1d=None):
     return data
 
 
-def read_from_minisv_desi(in_dir, catalog, pk1d=None):
+def read_from_minisv_desi(in_dir, catalog, pk1d=None, usesinglenights=False, useall=False):
     """Reads the spectra and formats its data as Forest instances.
     Unlike the read_from_desi routine, this orders things by tile/petal
     Routine used to treat the DESI mini-SV data.
@@ -1069,19 +1076,39 @@ def read_from_minisv_desi(in_dir, catalog, pk1d=None):
 
     data = {}
     num_data = 0
-
-    files_in = glob.glob(os.path.join(in_dir, "**/coadd-*.fits"),
+    if usesinglenights:
+        files_in = glob.glob(os.path.join(in_dir, "**/coadd-*.fits"),
                          recursive=True)
-    petal_tile_night = [
-        f"{entry['PETAL_LOC']}-{entry['TILEID']}-{entry['NIGHT']}"
-        for entry in catalog
-    ]
-    petal_tile_night_unique = np.unique(petal_tile_night)
-    filenames = []
-    for f_in in files_in:
-        for ptn in petal_tile_night_unique:
+        petal_tile_night = [
+            f"{entry['PETAL_LOC']}-{entry['TILEID']}-{entry['NIGHT']}"
+            for entry in catalog
+        ]
+        petal_tile_night_unique = np.unique(petal_tile_night)
+    
+        filenames = []
+        for f_in in files_in:
+          for ptn in petal_tile_night_unique:
             if ptn in os.path.basename(f_in):
                 filenames.append(f_in)
+    else:
+        if useall:
+            files_in = glob.glob(os.path.join(in_dir, "**/all/**/coadd-*.fits"),
+                         recursive=True)
+        else:
+            files_in = glob.glob(os.path.join(in_dir, "**/deep/**/coadd-*.fits"),
+                         recursive=True)
+        petal_tile = [
+            f"{entry['PETAL_LOC']}-{entry['TILEID']}"
+            for entry in catalog
+        ]
+        petal_tile_unique = np.unique(petal_tile)
+        filenames = []
+        for f_in in files_in:
+          for pt in petal_tile_unique:
+            if pt in os.path.basename(f_in):
+                filenames.append(f_in)
+
+        
     #filenames = []
     #for entry in catalog:
     #    fi = (f"{entry['TILEID']}/{entry['NIGHT']}/"+

--- a/py/picca/test/test_cor.py
+++ b/py/picca/test/test_cor.py
@@ -616,6 +616,7 @@ class TestCor(unittest.TestCase):
         cmd += " --nproc 1"
         cmd += " --best-obs"
         cmd += " --mask-file " + path_to_etc + "/list_veto_line_Pk1D.txt"
+        cmd += " --use-single-nights"
         returncode = subprocess.call(cmd, shell=True)
         self.assertEqual(returncode, 0, "delta_Pk1D_minisv did not finish")
 


### PR DESCRIPTION
This is to allow using the deep spectra by default in DESI SV mode, there's 2 flags for picca_deltas to allow changing to all or allow to use the previous behaviour, i.e. selecting only spectra from specific nights.