### PR TITLE
Adapt for new mocks without reso matrix for each spectrum

### DIFF
--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1008,7 +1008,8 @@ def read_from_desi(in_dir, catalog, pk1d=None):
                     spec["RESO"] = hdul[f"{color}_RESOLUTION"].read()
                 else:
                     try:
-                        filename_truth=filename.replace('spectra-','truth-')
+                        filename_truth=f"{in_dir}/{healpix//100}/{healpix}/truth-{in_nside}-{healpix}.fits"
+
                         with fitsio.FITS(filename_truth) as hdul_truth:
                             spec["RESO"] = hdul_truth[f"{color}_RESOLUTION"].read()
                     except IOError:

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1212,7 +1212,10 @@ def read_from_minisv_desi(in_dir, catalog, pk1d=None, usesinglenights=False, use
                 flux = spec['FL'][w_t].copy()
 
                 if pk1d is not None:
-                    reso_sum = spec['RESO'][w_t].copy()
+                    if len(spec['RESO'])>1:
+                        reso_sum = spec['RESO'][w_t].copy()
+                    else:
+                        reso_sum = spec['RESO'][0].copy()
                     reso_in_km_per_s = np.real(
                         spectral_resolution_desi(reso_sum, spec['log_lambda']))
                     exposures_diff = np.zeros(spec['log_lambda'].shape)

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1006,21 +1006,19 @@ def read_from_desi(in_dir, catalog, pk1d=None):
                     spec[key][w] = 0.
                 if f"{color}_RESOLUTION" in hdul:
                     spec["RESO"] = hdul[f"{color}_RESOLUTION"].read()
-                else:
+                elif pk1d is not None:
+                    filename_truth=f"{in_dir}/{healpix//100}/{healpix}/truth-{in_nside}-{healpix}.fits"
                     try:
-                        filename_truth=f"{in_dir}/{healpix//100}/{healpix}/truth-{in_nside}-{healpix}.fits"
-
                         with fitsio.FITS(filename_truth) as hdul_truth:
                             spec["RESO"] = hdul_truth[f"{color}_RESOLUTION"].read()
                     except IOError:
-                        userprint(f"Error reading truth file {filename_truth}")    
-                        breakpoint()
+                        userprint(f"Error reading truth file {filename_truth}")   
                     except KeyError:
-                        userprint(f"Error reading resolution from truth file for pix {healpix}")    
+                        userprint(f"Error reading resolution from truth file for pix {healpix}")
                     else:
-                        reso_from_truth=True
-
-                            
+                        if not reso_from_truth:
+                            userprint('Did not find resolution matrix in spectrum files, using resolution from truth files')
+                            reso_from_truth=True
                 spec_data[color] = spec
             except OSError:
                 userprint(f"ERROR: while reading {color} band from {filename}")

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1012,7 +1012,8 @@ def read_from_desi(in_dir, catalog, pk1d=None):
                         with fitsio.FITS(filename_truth) as hdul_truth:
                             spec["RESO"] = hdul_truth[f"{color}_RESOLUTION"].read()
                     except IOError:
-                        userprint(f"Error reading truth file for resolution for pix {healpix}")    
+                        userprint(f"Error reading truth file {filename_truth}")    
+                        breakpoint()
                     except KeyError:
                         userprint(f"Error reading resolution from truth file for pix {healpix}")    
                     else:


### PR DESCRIPTION
This reads the resolution matrix from the truth file to allow running picca deltas in Pk1d mode for light quickquasar spectra. This is skipped for the BAO analysis which never uses the resolution anyway