### PR TITLE
Update the template pk computation

### DIFF
--- a/bin/picca_compute_pk_pksb.py
+++ b/bin/picca_compute_pk_pksb.py
@@ -78,8 +78,10 @@ if __name__ == '__main__':
     cat['TCMB'] = pars.TCMB
     cat['NS'] = pars.InitPower.ns
     cat['ZREF'] = pars.Transfer.PK_redshifts[0]
-    cat['SIGMA8'] = results.get_sigma8()[1]
-    cat['F'] = results.get_fsigma8()[0]/results.get_sigma8()[0]
+    cat['SIGMA8_ZREF'] = results.get_sigma8()[0]
+    cat['SIGMA8_Z0'] = results.get_sigma8()[1]
+    cat['F_ZREF'] = results.get_fsigma8()[0]/results.get_sigma8()[0]
+    cat['F_Z0'] = results.get_fsigma8()[1]/results.get_sigma8()[1]
     cat['ZDRAG'] = pars2['zdrag']
     cat['RDRAG'] = pars2['rdrag']
 
@@ -100,7 +102,7 @@ if __name__ == '__main__':
     sb2_rmin = 150.*coef_Planck2015
     sb2_rmax = 190.*coef_Planck2015
     xi = nbodykit.cosmology.correlation.pk_to_xi(k,pk)
-    r = 10**np.linspace(-7.,3.5,1e4)
+    r = np.logspace(-7., 3.5, 10000)
     xi = xi(r)
 
     def f_xiSB(r,am3,am2,am1,a0,a1):


### PR DESCRIPTION
Just a few updates to the picca_compute_pk_pksb.py script. We are now writing to file the sigma8 and f (growth rate) values at both redshift 0 and the reference redshift. Previously we were writing sigma8(z=0) and f(z=zref) with no reference to the redshift.
Also fixed a bug when calling linspace and updated to logspace for simplicity.