### PR TITLE
setup had issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import glob
 
 from setuptools import setup
 
-scripts = sorted(glob.glob('bin/*'))
+scripts = sorted(glob.glob('bin/picca*'))
 
 description = "Package for Igm Cosmological-Correlations Analyses"
 


### PR DESCRIPTION
The previous setup file made trouble when installing without developing mode (i.e. `pip install .` instead of `pip install -e .`). This should fix those issues