### PR TITLE
changing coadding to always return the forest with data should there be one without data

### DIFF
--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -573,7 +573,10 @@ class Forest(QSO):
             The coadded forest.
         """
         if self.log_lambda is None or other.log_lambda is None:
-            return self
+            if other.log_lambda is None:
+                return self
+            else:
+                return other
 
         # this should contain all quantities that are to be coadded using
         # ivar weighting

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1296,7 +1296,7 @@ def read_from_minisv_desi(in_dir, catalog, pk1d=None, usesinglenights=False, use
                 if forest is None:
                     forest = copy.deepcopy(forest_temp)
                 else:
-                    forest.coadd(forest_temp)
+                    forest = forest.coadd(forest_temp)
             if not usehealpix:
                 if plate_spec not in data:
                     data[plate_spec] = []
@@ -1307,16 +1307,16 @@ def read_from_minisv_desi(in_dir, catalog, pk1d=None, usesinglenights=False, use
                     data[in_healpixs[w_t]] = []
                 #this might be slow, but would coadd objects with the same targetid even if on multiple tiles
                 do_append=True
+#                if forest.log_lambda is None:
+#                    breakpoint()
                 for index_coadd,forest_existing in enumerate(data[in_healpixs[w_t]]):
                     if forest_existing.thingid==forest.thingid:
-                        forest_existing.coadd(forest)
+                        forest_existing = forest_existing.coadd(forest)
                         do_append=False
                         break
                 if do_append:
                     data[in_healpixs[w_t]].append(forest)
                     num_data += 1
-
-
 
     userprint("found {} quasars in input files\n".format(num_data))
 

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1296,6 +1296,7 @@ def read_from_minisv_desi(in_dir, catalog, pk1d=None, usesinglenights=False, use
                 if forest is None:
                     forest = copy.deepcopy(forest_temp)
                 else:
+                    #need to do the function call here to allow passing back forest_temp if forest is invalid
                     forest = forest.coadd(forest_temp)
             if not usehealpix:
                 if plate_spec not in data:
@@ -1307,14 +1308,14 @@ def read_from_minisv_desi(in_dir, catalog, pk1d=None, usesinglenights=False, use
                     data[in_healpixs[w_t]] = []
                 #this might be slow, but would coadd objects with the same targetid even if on multiple tiles
                 do_append=True
-#                if forest.log_lambda is None:
-#                    breakpoint()
-                for index_coadd,forest_existing in enumerate(data[in_healpixs[w_t]]):
+                for forest_existing in data[in_healpixs[w_t]]:
                     if forest_existing.thingid==forest.thingid:
-                        forest_existing = forest_existing.coadd(forest)
+                        #the method call works as long as only valid forests are stored below
+                        forest_existing.coadd(forest)
                         do_append=False
                         break
-                if do_append:
+                #need to make sure that the forest is valid and the object isn't already in
+                if do_append and forest.log_lambda is not None:
                     data[in_healpixs[w_t]].append(forest)
                     num_data += 1
 


### PR DESCRIPTION
It looks like there was a bug in the coadding routine (see https://desisurvey.slack.com/archives/CTJ0GRSR3/p1627042008070600 and following). The coadding routine in  py/picca/data.py previously returned the current object should either it (self) or the forest to be coadded to it (other) contain no data. 
In case of coadding multiple bands this led to trouble when B (which is treated) first contains no useful data (e.g. when looking at the MgII forest that mostly lives in R/Z). I changed it to always return the forest with useful data from the coadding routine (note that it is also used as a method sometimes, this usecase still needs to be fixed).