### PR TITLE
set dmat_name when matrix is not provided

### DIFF
--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -189,6 +189,7 @@ def main(cmdargs):
         r_par_dmat = r_par.copy()
         r_trans_dmat = r_trans.copy()
         z_dmat = z.copy()
+        dmat_name = 'DM_EMPTY'
 
     results = fitsio.FITS(args.out, 'rw', clobber=True)
     header = [


### PR DESCRIPTION
This tiny PR addresses issue #795 by setting dmat_name to "DM_EMPTY" when a distortion matrix is not provided to picca_export.py