### PR TITLE
Add simple strategy E implementation.

### DIFF
--- a/bin/picca_deltas.py
+++ b/bin/picca_deltas.py
@@ -417,7 +417,7 @@ def main(cmdargs):
                         help=('Use all dir for input spectra (DESI SV)'))
     parser.add_argument('--blinding-desi',
                         type=str,
-                        default="minimal",
+                        default="corr_yshift",
                         required=False,
                         help='Blinding strategy. "none" for no blinding')
 
@@ -430,8 +430,8 @@ def main(cmdargs):
 
     # comment this when ready to unblind
     if args.blinding_desi == "none":
-        print("WARINING: --blinding-desi is being ignored. 'minimal' blinding engaged")
-        args.blinding_desi = "minimal"
+        userprint("WARINING: --blinding-desi is being ignored. 'corr_yshift' blinding engaged")
+        args.blinding_desi = "corr_yshift"
 
     # setup forest class variables
     Forest.log_lambda_min = np.log10(args.lambda_min)

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -253,10 +253,15 @@ def main(cmdargs):
 
     # Check if we need blinding and apply it
     if 'BLIND' in data_name or blinding != 'none':
-        if blinding != 'corr_yshift':
+        if blinding == 'corr_yshift':
+            userprint("Blinding using strategy corr_yshift.")
+        elif blinding == 'minimal':
             blinding = 'corr_yshift'
-            print("Only strategy E called 'corr_yshift' is allowed for now."
-                  " This will be applied automatilly.")
+            userprint("Only strategy E called 'corr_yshift' is allowed for now."
+                      " This will be applied automatilly.")
+        else:
+            raise ValueError("Expected blinding to be 'corr_yshift' or 'minimal'."
+                             " Found {}.".format(blinding))
 
         if args.blind_corr_type is None:
             raise argparse.ArgumentError("Blinding strategy 'corr_yshift' requires"
@@ -264,7 +269,7 @@ def main(cmdargs):
 
         # Read the blinding file and get the right template
         blinding_filename = ('/global/cfs/projectdirs/desi/users/acuceu/notebooks/'
-                             'vega_models/blinding/blinding_file/test_2.h5')
+                             'vega_models/blinding/blinding_file/blinding_model_2.h5')
         if not os.path.isfile(blinding_filename):
             raise RuntimeError("Missing blinding file. Make sure you are running at"
                                " NERSC or contact picca developers")

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -70,7 +70,7 @@ def main(cmdargs):
         help='Do not smooth the covariance matrix')
 
     parser.add_argument(
-        '--blind_corr_type',
+        '--blind-corr-type',
         default=None,
         choices=['lyaxlya', 'lyaxlyb', 'qsoxlya', 'qsoxlyb'],
         help='Type of correlation. Required to apply blinding in DESI')

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -273,7 +273,6 @@ def main(cmdargs):
         if not os.path.isfile(blinding_filename):
             raise RuntimeError("Missing blinding file. Make sure you are running at"
                                " NERSC or contact picca developers")
-
         blinding_file = h5py.File(blinding_filename, 'r')
         hex_diff = np.array(blinding_file['blinding'][args.blind_corr_type]).astype(str)
         diff = np.array([float.fromhex(x) for x in hex_diff])

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -242,6 +242,7 @@ def main(cmdargs):
         'Covariance matrix', 'Distortion matrix', 'Number of pairs'
     ]
 
+    # Check if we need blinding and apply it
     if 'BLIND' in data_name or blinding != 'none':
         if blinding != 'corr_yshift':
             print('Only strategy E called "corr_yshift" is allowed for now.'
@@ -263,15 +264,19 @@ def main(cmdargs):
             raise ValueError('Unknown binning. Cannot blind. Please raise an issue'
                              ' or contact picca developers.')
 
+        # Read the blinding file and get the right template
         blinding_path = ('/global/cfs/projectdirs/desi/users/acuceu/notebooks/'
                          'vega_models/blinding/blinding_file/test_2.h5')
         blinding_file = h5py.File(blinding_path, 'r')
         hex_diff = np.array(blinding_file['blinding'][blind_corr]).astype(str)
         diff = np.array([float.fromhex(x) for x in hex_diff])
 
+        # Check that the shapes match
         if np.shape(xi) != np.shape(diff):
             raise ValueError('Unknown binning. Cannot blind. Please raise an issue'
                              ' or contact picca developers.')
+
+        # Add blinding
         xi = xi + diff
 
     results.write([xi, r_par, r_trans, z, covariance, dmat, num_pairs],

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -256,7 +256,7 @@ def main(cmdargs):
                 blind_corr = 'lyaxlya'
         elif len(xi) == 100:
             assert 'qso' in args.data
-            if 'lyb' in args.data:
+            if 'lyb' in args.data or 'Lyb' in args.data:
                 blind_corr = 'qsoxlyb'
             else:
                 blind_corr = 'qsoxlya'

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -6,6 +6,7 @@ import fitsio
 import numpy as np
 import scipy.linalg
 import h5py
+import os.path
 
 from picca.utils import smooth_cov, compute_cov
 from picca.utils import userprint
@@ -265,9 +266,13 @@ def main(cmdargs):
                              ' or contact picca developers.')
 
         # Read the blinding file and get the right template
-        blinding_path = ('/global/cfs/projectdirs/desi/users/acuceu/notebooks/'
-                         'vega_models/blinding/blinding_file/test_2.h5')
-        blinding_file = h5py.File(blinding_path, 'r')
+        blinding_filename = ('/global/cfs/projectdirs/desi/users/acuceu/notebooks/'
+                             'vega_models/blinding/blinding_file/test_2.h5')
+        if not os.path.isfile(blinding_filename):
+            raise ValueError('Missing blinding file. Make sure you are running at'
+                             ' NERSC or contact picca developers')
+
+        blinding_file = h5py.File(blinding_filename, 'r')
         hex_diff = np.array(blinding_file['blinding'][blind_corr]).astype(str)
         diff = np.array([float.fromhex(x) for x in hex_diff])
 

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -254,6 +254,7 @@ def main(cmdargs):
     # Check if we need blinding and apply it
     if 'BLIND' in data_name or blinding != 'none':
         if blinding != 'corr_yshift':
+            blinding = 'corr_yshift'
             print("Only strategy E called 'corr_yshift' is allowed for now."
                   " This will be applied automatilly.")
 

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -268,8 +268,8 @@ def main(cmdargs):
                                          " argument --blind_corr_type.")
 
         # Read the blinding file and get the right template
-        blinding_filename = ('/global/cfs/projectdirs/desi/users/acuceu/notebooks/'
-                             'vega_models/blinding/blinding_file/blinding_model_2.h5')
+        blinding_filename = ('/global/cfs/projectdirs/desi/science/lya/y1-kp6/'
+                             'blinding/y1_blinding_v1_standard_04_10_2021.h5')
         if not os.path.isfile(blinding_filename):
             raise RuntimeError("Missing blinding file. Make sure you are running at"
                                " NERSC or contact picca developers")

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -101,8 +101,12 @@ def main(cmdargs):
 
     if "BLINDING" in head:
         blinding = head["BLINDING"]
-    # older runs are not from DESI main survey and should not be blinded
+        if blinding == 'minimal':
+            blinding = 'corr_yshift'
+            userprint("The minimal strategy is no longer supported."
+                        "Automatically switch to corr_yshift.")
     else:
+        # if BLINDING keyword not present (old file), ignore blinding
         blinding = "none"
     hdul.close()
 
@@ -255,10 +259,6 @@ def main(cmdargs):
     if 'BLIND' in data_name or blinding != 'none':
         if blinding == 'corr_yshift':
             userprint("Blinding using strategy corr_yshift.")
-        elif blinding == 'minimal':
-            blinding = 'corr_yshift'
-            userprint("Only strategy E called 'corr_yshift' is allowed for now."
-                      " This will be applied automatilly.")
         else:
             raise ValueError("Expected blinding to be 'corr_yshift' or 'minimal'."
                              " Found {}.".format(blinding))

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -104,13 +104,13 @@ def main(cmdargs):
         if blinding == 'minimal':
             blinding = 'corr_yshift'
             userprint("The minimal strategy is no longer supported."
-                        "Automatically switch to corr_yshift.")
+                      "Automatically switch to corr_yshift.")
     else:
         # if BLINDING keyword not present (old file), ignore blinding
         blinding = "none"
     hdul.close()
 
-    if not args.remove_shuffled_correlation is None:
+    if args.remove_shuffled_correlation is not None:
         hdul = fitsio.FITS(args.remove_shuffled_correlation)
         xi_shuffled = hdul['COR'][data_name][:]
         weight_shuffled = hdul['COR']['WE'][:]
@@ -299,5 +299,5 @@ def main(cmdargs):
 
 
 if __name__ == '__main__':
-    cmdargs=sys.argv[1:]
+    cmdargs = sys.argv[1:]
     main(cmdargs)

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -264,8 +264,8 @@ def main(cmdargs):
                              " Found {}.".format(blinding))
 
         if args.blind_corr_type is None:
-            raise argparse.ArgumentError("Blinding strategy 'corr_yshift' requires"
-                                         " argument --blind_corr_type.")
+            raise ValueError("Blinding strategy 'corr_yshift' requires"
+                             " argument --blind_corr_type.")
 
         # Read the blinding file and get the right template
         blinding_filename = ('/global/cfs/projectdirs/desi/science/lya/y1-kp6/'

--- a/py/picca/constants.py
+++ b/py/picca/constants.py
@@ -20,7 +20,7 @@ SPEED_LIGHT = speed_light/1000. # [km/s]
 # different strategies are explained in
 # https://desi.lbl.gov/trac/wiki/keyprojects/y1kp6/Blinding
 ACCEPTED_BLINDING_STRATEGIES = ["none", "minimal", "strategyB", "strategyC",
-    "strategyBC"]
+    "strategyBC", "corr_yshift"]
 
 class Cosmo(object):
     """This class defines the fiducial cosmology


### PR DESCRIPTION
This is adds a quick version of strategy E (corr_yshift) where we use an external file (saved on NERSC) to store the difference between a blind model and an unblind model. This difference gets added to the measured correlation at the picca_export step. Still needs testing, and the real file to be produced in a common DESI directory at NERSC.