### PR TITLE
Test night exception

### DIFF
--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1221,7 +1221,7 @@ def read_from_minisv_desi(in_dir, catalog, pk1d=None, usesinglenights=False, use
             print(f'{filename} does not have a NIGHT')
             try:
                 night_spec = int(filename.split('-')[-1].split('.')[0])
-            except:
+            except ValueError:
                 night_spec = int(filename.split('thru')[-1].split('.')[0])
 
         targetid_spec = fibermap['TARGETID']

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1218,7 +1218,11 @@ def read_from_minisv_desi(in_dir, catalog, pk1d=None, usesinglenights=False, use
                 night_spec = fibermap['LAST_NIGHT'][0]
         else:
             #pre-andes tiles don't have this in the fibermap
-            night_spec = int(filename.split('-')[-1].split('.')[0])
+            print(f'{filename} does not have a NIGHT')
+            try:
+                night_spec = int(filename.split('-')[-1].split('.')[0])
+            except:
+                night_spec = int(filename.split('thru')[-1].split('.')[0])
 
         targetid_spec = fibermap['TARGETID']
 


### PR DESCRIPTION
This only allows current daily files to run through picca, previously there were filename checks based on NIGHT, but this is not existing for all data, which was breaking the analysis at the position of this fix.
The fix now fills the NIGHT info with the last night according to the filename.