### PR TITLE
fix for --mode desi_mock for the xcf and xdmat 

### DIFF
--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -169,7 +169,7 @@ def read_drq(drq_filename,
             keep_columns += ['SV1_DESI_TARGET']
         if 'SV3_DESI_TARGET' in catalog.colnames:
             keep_columns += ['SV3_DESI_TARGET']
-        
+
 
     else:
         obj_id_name = 'THING_ID'
@@ -1630,7 +1630,7 @@ def read_objects(filename,
                     entry['PLATE'], entry['MJD'], entry['FIBERID'])
                 for entry in catalog[w]
             ]
-    
+
         for obj in objs[healpix]:
             obj.weights = ((1. + obj.z_qso) / (1. + z_ref))**(alpha - 1.)
             if not cosmo is None:


### PR DESCRIPTION
It should not be necessary to convert the mock catalog to drq with `picca_converters.py` if we use --mode desi_mocks. This small change should fix that, but I'd like @HiramHerrera or anyone else to test it ... 