### PR TITLE
add desi_healpix as mode for picca_metal_xdmat

### DIFF
--- a/bin/picca_metal_xdmat.py
+++ b/bin/picca_metal_xdmat.py
@@ -71,7 +71,7 @@ def main(cmdargs):
                         '--mode',
                         type=str,
                         default='sdss',
-                        choices=['sdss','desi'],
+                        choices=['sdss','desi','desi_mocks','desi_healpix'],
                         required=False,
                         help='type of catalog supplied, default sdss')
 


### PR DESCRIPTION
Small fix to run metal matrix for the cross-correlation in Everest healpix data