### PR TITLE
Look for LOS_ID in delta files

### DIFF
--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -1201,7 +1201,12 @@ class Delta(QSO):
         fitiing. See equations 5 and 6 of du Mas des Bourboux et al. 2020
         """
         # 2nd term in equation 6
-        mean_delta = np.average(self.delta, weights=self.weights)
+        sum_weights=np.sum(self.weights)
+        if sum_weights > 0.0:
+            mean_delta = np.average(self.delta, weights=self.weights)
+        else:
+            # should probably write a warning
+            return
 
         # 3rd term in equation 6
         res = 0

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -1073,19 +1073,28 @@ class Delta(QSO):
             weights = hdu['WEIGHT'][:].astype(float)
             cont = hdu['CONT'][:].astype(float)
 
-        thingid = header['THING_ID']
+        if 'THING_ID' in header:
+            los_id = header['THING_ID']
+            plate = header['PLATE']
+            mjd = header['MJD']
+            fiberid = header['FIBERID']
+        elif 'LOS_ID' in header:
+            los_id = header['LOS_ID']
+            plate=los_id
+            mjd=los_id
+            fiberid=los_id
+        else:
+            raise Exception("Could not find THING_ID or LOS_ID")
+
         ra = header['RA']
         dec = header['DEC']
         z_qso = header['Z']
-        plate = header['PLATE']
-        mjd = header['MJD']
-        fiberid = header['FIBERID']
         try:
             order = header['ORDER']
         except KeyError:
             order = 1
 
-        return cls(thingid, ra, dec, z_qso, plate, mjd, fiberid, log_lambda,
+        return cls(los_id, ra, dec, z_qso, plate, mjd, fiberid, log_lambda,
                    weights, cont, delta, order, ivar, exposures_diff, mean_snr,
                    mean_reso, mean_z, delta_log_lambda)
 

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1413,7 +1413,7 @@ def read_blinding(in_dir):
     return blinding
 
 
-def read_delta_file(filename, from_image=False):
+def read_delta_file(filename, from_image=None):
     """Extracts deltas from a single file.
     Args:
         filename: str


### PR DESCRIPTION
The current master branch looks for THING_ID in the delta files, but the new continuum branch (delta_extraction) writes instead LOS_ID (because DESI and other surveys do not have THING_ID).

In the long run we should rewrite the rest of Picca to be less SDSS-scentric (and scrap PLATE, MJD, FIBER), but meanwhile this pull request provides a quick fix so that we can measure correlations from the new delta files. 

I also used this PR to fix a couple of minor bugs that I encountered.