### PR TITLE
Fix read DLAs for eBOSS mocks. Set new eboss_mocks replacing desi mode

### DIFF
--- a/bin/picca_deltas.py
+++ b/bin/picca_deltas.py
@@ -168,14 +168,14 @@ def main(cmdargs):
 
     parser.add_argument('--mode',
                         type=str,
-                        choices=['pix', 'spec','spcframe','spplate','desi',
+                        choices=['pix', 'spec','spcframe','spplate','eboss_mocks','desi',
                                  'desi_healpix','desi_survey_tilebased',
                                  'desi_sv_no_coadd','desi_mocks','desiminisv'],
                         default='pix',
                         required=False,
                         help=('''Open mode of the spectra files: pix, spec, 
-                              spcframe, spplate, desi_mocks (formerly known as desi), 
-                              desi_healpix (for healpix based coadded data),
+                              spcframe, spplate, eboss_mocks (formerly known as desi, cover quickquasar mocks using eBOSS naming
+                              convention), desi_mock, desi_healpix (for healpix based coadded data),
                               desi_survey_tilebased (for tilebased data with coadding), 
                               desi_sv_no_coadd (without coadding across tiles, will output in tile format)'''))
 
@@ -527,6 +527,10 @@ def main(cmdargs):
         Forest.extinction_bv_map = io.read_dust_map(args.dust_map)
 
     log_file = open(os.path.expandvars(args.log), 'w')
+
+    if args.mode == "desi":
+        args.mode="eboss_mock"
+        userprint("WARNING: 'desi' mode is deprecated, changing to use 'eboss_mock' for quickquasar mocks using eBOSS naming convention")
 
     # Read data
     (data, num_data, nside,

--- a/bin/picca_xcf.py
+++ b/bin/picca_xcf.py
@@ -73,7 +73,7 @@ def main(cmdargs):
     parser.add_argument('--mode',
                         type=str,
                         required=False,
-                        choices=['desi','desi_healpix','desi_mocks','sdss'],
+                        choices=['eboss_mocks','desi_healpix','desi_mocks','desi','sdss'],
                         default='sdss',
                         help='Mode for reading the catalog (default sdss)'
                         )
@@ -277,6 +277,10 @@ def main(cmdargs):
         userprint("z_max_obj = {}".format(args.z_max_obj), end="")
 
     ### Read objects
+    if args.mode == "desi":
+        args.mode="eboss_mocks"
+        userprint("WARNING: 'desi' mode is deprecated, changing to use 'eboss_mock' for quickquasar mocks using eBOSS naming convention")
+
     objs, z_min2 = io.read_objects(args.drq, args.nside, args.z_min_obj,
                                    args.z_max_obj, args.z_evol_obj, args.z_ref,
                                    cosmo, mode=args.mode)

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -176,7 +176,7 @@ def read_drq(drq_filename,
         obj_id_name = 'THING_ID'
         keep_columns += ['THING_ID', 'PLATE', 'MJD', 'FIBERID']
 
-    if mode == "desi_mocks":
+    if mode in ["desi_mocks", "eboss_mocks"]:
         for key in ['RA', 'DEC']:
             catalog[key] = catalog[key].astype('float64')
 
@@ -368,8 +368,9 @@ def read_data(in_dir,
 
     # read data taking the mode into account
     blinding = "none"
-    if mode in ["desi_mocks","desi_healpix","desi","desi_survey_tilebased", "spcframe", "spplate", "spec", "corrected-spec"]:
-        if mode in ["desi_mocks", "desi"]: #I still don't think we need two different modes since we are checking if truth files exist...
+    if mode in ["desi_mocks", "desi_healpix", "desi_survey_tilebased", "eboss_mocks", "spcframe", "spplate", "spec", "corrected-spec"]:
+        if mode in ["desi_mocks", "eboss_mocks"]:
+
             desi_nside = 16
             desi_prefix = f'spectra-{desi_nside}'
             pix_data, is_mock = read_from_desi(in_dir, catalog, desi_prefix, desi_nside, pk1d=pk1d)


### PR DESCRIPTION
Fix issue #821 by setting the new mode `eboss_mocks` which should cover any quickquasar mock catalog with eBOSS naming convention, i.e. actual eBOSS mocks and DESI mocks with eBOSS naming convention. 

I left the `desi` mode in the list of possible modes in order to not break older scripts, but internally it changes to `eboss_mocks`

@moonlovist could you please make sure this fix the issue you raised? Thanks! 

I'll try to set up a GitHub test to avoid breaking the functioning of the mocks. 