### PR TITLE
fix coadd for Pk1d

### DIFF
--- a/py/picca/delta_extraction/astronomical_objects/pk1d_forest.py
+++ b/py/picca/delta_extraction/astronomical_objects/pk1d_forest.py
@@ -326,6 +326,8 @@ class Pk1dForest(Forest):
         """
         bins, rebin_ivar, orig_ivar, w1, w2 = super().rebin()
         if len(rebin_ivar) == 0:
+            self.exposures_diff = np.array([])
+            self.reso = np.array([])
             return [], [], [], [], []
 
         # apply mask due to cuts in bin


### PR DESCRIPTION
This fixes coadds for Pk1d, the issue is that a coadd with a zero-pixel spectrum (due to masking of pixels outside the Lya forest range, e.g. the Z-band for most spectra) will result in a truncated ivar/lambda_/... without propagating this truncation to reso/exposure_diff.

This is fixed by explicitely setting those to empty arrays for this case. 