### PR TITLE
make dla masking independent of wavelength basis

### DIFF
--- a/py/picca/delta_extraction/masks/dla_mask.py
+++ b/py/picca/delta_extraction/masks/dla_mask.py
@@ -114,15 +114,12 @@ class DlaMask(Mask):
                 self.mask = Table.read(mask_file,
                                        names=('type', 'wave_min', 'wave_max', 'frame'),
                                        format='ascii')
-                self.mask['log_wave_min'] = np.log10(self.mask['wave_min'])
-                self.mask['log_wave_max'] = np.log10(self.mask['wave_max'])
                 self.mask = self.mask['frame'] == 'RF_DLA'
             except (OSError, ValueError):
                 raise MaskError("ERROR: Error while reading mask_file file "
                                 f"{mask_file}")
         else:
-            self.mask = Table(names=('type', 'wave_min', 'wave_max', 'frame',
-                                     'log_wave_min', 'log_wave_max'))
+            self.mask = Table(names=('type', 'wave_min', 'wave_max', 'frame'))
 
     def apply_mask(self, forest):
         """Apply the mask. The mask is done by removing the affected
@@ -156,9 +153,9 @@ class DlaMask(Mask):
                 for mask_range in self.mask:
                     for (z_abs, nhi) in self.los_ids.get(forest.los_id):
                         w &= ((lambda_ / (1. + z_abs) <
-                               10**mask_range['log_wave_min']) |
+                               mask_range['wave_min']) |
                               (lambda_ / (1. + z_abs) >
-                               10**mask_range['log_wave_max']))
+                               mask_range['wave_max']))
 
             # do the actual masking
             forest.transmission_correction *= dla_transmission

--- a/py/picca/delta_extraction/masks/dla_mask.py
+++ b/py/picca/delta_extraction/masks/dla_mask.py
@@ -146,7 +146,7 @@ class DlaMask(Mask):
 
         # load DLAs
         if self.los_ids.get(forest.los_id) is not None:
-            dla_transmission = np.ones(len(forest.log_lambda))
+            dla_transmission = np.ones(len(lambda_))
             for (z_abs, nhi) in self.los_ids.get(forest.los_id):
                 dla_transmission *= DlaProfile(lambda_, z_abs, nhi).transmission
 
@@ -155,10 +155,10 @@ class DlaMask(Mask):
             if len(self.mask) > 0:
                 for mask_range in self.mask:
                     for (z_abs, nhi) in self.los_ids.get(forest.los_id):
-                        w &= ((forest.log_lambda - np.log10(1. + z_abs) <
-                               mask_range['log_wave_min']) |
-                              (forest.log_lambda - np.log10(1. + z_abs) >
-                               mask_range['log_wave_max']))
+                        w &= ((lambda_ / (1. + z_abs) <
+                               10**mask_range['log_wave_min']) |
+                              (lambda_ / (1. + z_abs) >
+                               10**mask_range['log_wave_max']))
 
             # do the actual masking
             forest.transmission_correction *= dla_transmission


### PR DESCRIPTION
This should not change anything for logλ analyses, but allows DLA masking for linear λ analyses (which crashed before, but does not crash with this). If I read this correctly the DlaProfile expects λ anyway and this only affects the masking related to DLAs which has not been treated for both cases.