### PR TITLE
rebin moved outside of init

### DIFF
--- a/py/picca/delta_extraction/astronomical_objects/desi_forest.py
+++ b/py/picca/delta_extraction/astronomical_objects/desi_forest.py
@@ -167,9 +167,6 @@ class DesiForest(Forest):
         kwargs["los_id"] = self.targetid
         super().__init__(**kwargs)
 
-        # rebin arrays
-        super().rebin()
-
     def coadd(self, other):
         """Coadd the information of another forest.
 

--- a/py/picca/delta_extraction/astronomical_objects/desi_pk1d_forest.py
+++ b/py/picca/delta_extraction/astronomical_objects/desi_pk1d_forest.py
@@ -159,8 +159,3 @@ class DesiPk1dForest(DesiForest, Pk1dForest):
         AstronomicalObjectError if there are missing variables
         """
         super().__init__(**kwargs)
-
-        # rebin arrays
-        # this needs to happen after flux, ivar arrays are initialized by
-        # Forest constructor
-        super().rebin()

--- a/py/picca/delta_extraction/astronomical_objects/sdss_forest.py
+++ b/py/picca/delta_extraction/astronomical_objects/sdss_forest.py
@@ -170,11 +170,6 @@ class SdssForest(Forest):
         kwargs["los_id"] = self.thingid
         super().__init__(**kwargs)
 
-        # rebin arrays
-        # this needs to happen after flux and ivar arrays are initialized by
-        # Forest constructor
-        super().rebin()
-
     def coadd(self, other):
         """Coadd the information of another forest.
 

--- a/py/picca/delta_extraction/astronomical_objects/sdss_pk1d_forest.py
+++ b/py/picca/delta_extraction/astronomical_objects/sdss_pk1d_forest.py
@@ -154,8 +154,3 @@ class SdssPk1dForest(SdssForest, Pk1dForest):
         AstronomicalObjectError if there are missing variables
         """
         super().__init__(**kwargs)
-
-        # rebin arrays
-        # this needs to happen after flux, ivar arrays are initialized by
-        # Forest constructor
-        super().rebin()

--- a/py/picca/delta_extraction/data_catalogues/desi_healpix.py
+++ b/py/picca/delta_extraction/data_catalogues/desi_healpix.py
@@ -231,6 +231,12 @@ class DesiHealpix(DesiData):
                     raise DataError("Unkown analysis type. Expected 'BAO 3D'"
                                     f"or 'PK 1D'. Found '{self.analysis_type}'")
 
+                # rebin arrays
+                # this needs to happen after all arrays are initialized by
+                # Forest constructor
+                forest.rebin()
+
+                # keep the forest
                 if targetid in forests_by_targetid:
                     forests_by_targetid[targetid].coadd(forest)
                 else:

--- a/py/picca/delta_extraction/data_catalogues/desi_tile.py
+++ b/py/picca/delta_extraction/data_catalogues/desi_tile.py
@@ -294,6 +294,12 @@ class DesiTile(DesiData):
                         raise DataError("Unkown analysis type. Expected 'BAO 3D'"
                                         f"or 'PK 1D'. Found '{self.analysis_type}'")
 
+                    # rebin arrays
+                    # this needs to happen after all arrays are initialized by
+                    # Forest constructor
+                    forest.rebin()
+
+                    # add the forest to list
                     if targetid in forests_by_targetid:
                         forests_by_targetid[targetid].coadd(forest)
                     else:

--- a/py/picca/delta_extraction/data_catalogues/sdss_data.py
+++ b/py/picca/delta_extraction/data_catalogues/sdss_data.py
@@ -213,6 +213,7 @@ class SdssData(Data):
             else:
                 raise DataError(f"analysis_type = {self.analysis_type}")
 
+            forest.rebin()
             if thingid in forests_by_thingid:
                 forests_by_thingid[thingid].coadd(forest)
             else:
@@ -297,6 +298,13 @@ class SdssData(Data):
                             "exposures_diff": exposures_diff,
                             "reso": reso
                         })
+
+                # rebin arrays
+                # this needs to happen after all arrays are initialized by
+                # Forest constructor
+                forest.rebin()
+
+                # keep the forest
                 if thingid in forests_by_thingid:
                     forests_by_thingid[thingid].coadd(forest)
                 else:

--- a/py/picca/tests/delta_extraction/astronomical_object_tests.py
+++ b/py/picca/tests/delta_extraction/astronomical_object_tests.py
@@ -655,6 +655,7 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a DesiForest
         test_obj = DesiForest(**kwargs_desi_forest)
+        test_obj.rebin()
         self.assert_forest_object(test_obj, kwargs_desi_forest_rebin)
 
         # create forest with extra variables
@@ -663,12 +664,14 @@ class AstronomicalObjectTest(AbstractTest):
             "test variable": "test",
         })
         test_obj = DesiForest(**kwargs)
+        test_obj.rebin()
         self.assert_forest_object(test_obj, kwargs_desi_forest_rebin)
 
         # create a DesiForest with missing night, petal and tile
         kwargs = kwargs_desi_forest.copy()
         del kwargs["night"], kwargs["petal"], kwargs["tile"]
         test_obj = DesiForest(**kwargs)
+        test_obj.rebin()
 
         kwargs = kwargs_desi_forest_rebin.copy()
         kwargs["night"] = []
@@ -719,9 +722,11 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a DesiForest
         test_obj = DesiForest(**kwargs_desi_forest)
+        test_obj.rebin()
 
         # create a second DesiForest
         test_obj_other = DesiForest(**kwargs_desi_forest2)
+        test_obj_other.rebin()
 
         # coadd them
         test_obj.coadd(test_obj_other)
@@ -732,6 +737,7 @@ class AstronomicalObjectTest(AbstractTest):
         kwargs = kwargs_desi_forest2.copy()
         kwargs["targetid"] = 999
         test_obj_other = DesiForest(**kwargs)
+        test_obj_other.rebin()
 
         # coadding them whould raise an error
         with self.assertRaises(AstronomicalObjectError):
@@ -744,6 +750,7 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a DesiForest
         test_obj = DesiForest(**kwargs_desi_forest)
+        test_obj.rebin()
 
         self.assert_get_data(test_obj)
 
@@ -754,12 +761,14 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a DesiForest
         test_obj = DesiForest(**kwargs_desi_forest)
+        test_obj.rebin()
 
         # get header and test
         self.assert_get_header(test_obj)
 
         # create a second DesiForest and coadd it to the first
         test_obj_other = DesiForest(**kwargs_desi_forest2)
+        test_obj_other.rebin()
         test_obj.coadd(test_obj_other)
 
         # get header and test
@@ -784,6 +793,7 @@ class AstronomicalObjectTest(AbstractTest):
         setup_forest(wave_solution="lin")
 
         test_obj = DesiPk1dForest(**kwargs_desi_pk1d_forest)
+        test_obj.rebin()
         self.assertTrue(isinstance(test_obj, DesiPk1dForest))
         self.assertTrue(isinstance(test_obj, DesiForest))
         self.assertTrue(isinstance(test_obj, Pk1dForest))
@@ -798,12 +808,14 @@ class AstronomicalObjectTest(AbstractTest):
         self.assertTrue(isinstance(test_obj, DesiForest))
         self.assertTrue(isinstance(test_obj, Pk1dForest))
         test_obj = DesiPk1dForest(**kwargs)
+        test_obj.rebin()
 
         # create a DesiPk1dForest with missing night, petal and tile
         # create a DesiForest with missing night, petal and tile
         kwargs = kwargs_desi_pk1d_forest.copy()
         del kwargs["night"], kwargs["petal"], kwargs["tile"]
         test_obj = DesiPk1dForest(**kwargs)
+        test_obj.rebin()
 
         kwargs = kwargs_desi_pk1d_forest_rebin.copy()
         kwargs["night"] = []
@@ -886,12 +898,15 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a DesiPk1dForest
         test_obj = DesiPk1dForest(**kwargs_desi_pk1d_forest)
+        test_obj.rebin()
 
         # create a second DesiPk1dForest
         test_obj_other = DesiPk1dForest(**kwargs_desi_pk1d_forest2)
+        test_obj_other.rebin()
 
         # coadd them
         test_obj.coadd(test_obj_other)
+        test_obj.rebin()
         self.assert_forest_object(test_obj, kwargs_desi_pk1d_forest_coadd)
 
         # create a third DesiPk1dForest with different targetid
@@ -911,6 +926,7 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a DesiPk1dForest
         test_obj = DesiPk1dForest(**kwargs_desi_pk1d_forest)
+        test_obj.rebin()
         self.assert_get_data(test_obj)
 
     def test_desi_pk1d_forest_get_header(self):
@@ -921,10 +937,12 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a DesiPk1dForest
         test_obj = DesiPk1dForest(**kwargs_desi_pk1d_forest)
+        test_obj.rebin()
         self.assert_get_header(test_obj)
 
         # create a second DesiPk1dForest and coadd it to the first
         test_obj_other = DesiPk1dForest(**kwargs_desi_pk1d_forest2)
+        test_obj_other.rebin()
         test_obj.coadd(test_obj_other)
 
         # get header and test
@@ -983,6 +1001,7 @@ class AstronomicalObjectTest(AbstractTest):
         setup_forest(wave_solution="log")
 
         test_obj = Forest(**kwargs_forest_log)
+        test_obj.rebin()
 
         kwargs_forest_gt = kwargs_astronomical_object_gt.copy()
         for kwargs in kwargs_forest_gt.values():
@@ -1046,9 +1065,11 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a Forest
         test_obj = Forest(**kwargs_forest_log)
+        test_obj.rebin()
 
         # create a second SdssForest
         test_obj_other = Forest(**kwargs_forest_log2)
+        test_obj_other.rebin()
 
         # coadd them
         test_obj.coadd(test_obj_other)
@@ -1058,6 +1079,7 @@ class AstronomicalObjectTest(AbstractTest):
         kwargs = kwargs_forest_log2.copy()
         kwargs["los_id"] = 999
         test_obj_other = Forest(**kwargs)
+        test_obj_other.rebin()
 
         # coadding them whould raise an error
         with self.assertRaises(AstronomicalObjectError):
@@ -1069,9 +1091,11 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a Forest
         test_obj = Forest(**kwargs_forest_lin)
+        test_obj.rebin()
 
         # create a second Forest
         test_obj_other = Forest(**kwargs_forest_lin2)
+        test_obj_other.rebin()
 
         # coadd them
         test_obj.coadd(test_obj_other)
@@ -1084,6 +1108,7 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a Forest
         test_obj = Forest(**kwargs_forest_log)
+        test_obj.rebin()
         self.assert_get_data(test_obj)
 
         # set class variables; case: linear wavelength solution
@@ -1092,6 +1117,7 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a Forest
         test_obj = Forest(**kwargs_forest_lin)
+        test_obj.rebin()
         self.assert_get_data(test_obj)
 
     def test_forest_get_header(self):
@@ -1101,6 +1127,7 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a Forest
         test_obj = Forest(**kwargs_forest_log)
+        test_obj.rebin()
 
         # get header and test
         self.assert_get_header(test_obj)
@@ -1110,6 +1137,7 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a Forest
         test_obj = Forest(**kwargs_forest_lin)
+        test_obj.rebin()
 
         # get header and test
         self.assert_get_header(test_obj)
@@ -1155,9 +1183,11 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a Pk1dForest
         test_obj = Pk1dForest(**kwargs_pk1d_forest_log)
+        test_obj.rebin()
 
         # create a second Pk1dForest
         test_obj_other = Pk1dForest(**kwargs_pk1d_forest_log2)
+        test_obj_other.rebin()
 
         # coadd them
         test_obj.coadd(test_obj_other)
@@ -1167,6 +1197,7 @@ class AstronomicalObjectTest(AbstractTest):
         kwargs = kwargs_pk1d_forest_log2.copy()
         kwargs["los_id"] = 999
         test_obj_other = Pk1dForest(**kwargs)
+        test_obj_other.rebin()
 
         # coadding them should raise an error
         with self.assertRaises(AstronomicalObjectError):
@@ -1179,9 +1210,11 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a Forest
         test_obj = Pk1dForest(**kwargs_pk1d_forest_lin)
+        test_obj.rebin()
 
         # create a second Forest
         test_obj_other = Pk1dForest(**kwargs_pk1d_forest_lin2)
+        test_obj_other.rebin()
 
         # coadd them
         test_obj.coadd(test_obj_other)
@@ -1195,6 +1228,7 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a Pk1dForest
         test_obj = Pk1dForest(**kwargs_pk1d_forest_log)
+        test_obj.rebin()
         self.assert_get_data(test_obj)
 
         # set class variables; case: linear wavelength solution
@@ -1204,6 +1238,7 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a Forest
         test_obj = Pk1dForest(**kwargs_pk1d_forest_lin)
+        test_obj.rebin()
         self.assert_get_data(test_obj)
 
     def test_pk1d_forest_get_header(self):
@@ -1214,6 +1249,7 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a Pk1dForest
         test_obj = Pk1dForest(**kwargs_pk1d_forest_log)
+        test_obj.rebin()
 
         # get header and test
         self.assert_get_header(test_obj)
@@ -1223,6 +1259,7 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a Pk1dForest
         test_obj = Pk1dForest(**kwargs_pk1d_forest_lin)
+        test_obj.rebin()
 
         # get header and test
         self.assert_get_header(test_obj)
@@ -1240,6 +1277,7 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a SdssForest
         test_obj = SdssForest(**kwargs_sdss_forest)
+        test_obj.rebin()
         self.assertTrue(isinstance(test_obj, SdssForest))
         self.assertTrue(isinstance(test_obj, Forest))
         self.assert_forest_object(test_obj, kwargs_sdss_forest_rebin)
@@ -1250,6 +1288,7 @@ class AstronomicalObjectTest(AbstractTest):
             "test_variable": "test",
         })
         test_obj = SdssForest(**kwargs)
+        test_obj.rebin()
         self.assert_forest_object(test_obj, kwargs_sdss_forest_rebin)
 
         # create a SdssForest with missing SdssForest variables
@@ -1285,9 +1324,11 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a SdssForest
         test_obj = SdssForest(**kwargs_sdss_forest)
+        test_obj.rebin()
 
         # create a second SdssForest
         test_obj_other = SdssForest(**kwargs_sdss_forest2)
+        test_obj_other.rebin()
 
         # coadd them
         test_obj.coadd(test_obj_other)
@@ -1297,6 +1338,7 @@ class AstronomicalObjectTest(AbstractTest):
         kwargs = kwargs_sdss_forest2.copy()
         kwargs["thingid"] = 999
         test_obj_other = SdssForest(**kwargs)
+        test_obj_other.rebin()
 
         # coadding them should raise an error
         with self.assertRaises(AstronomicalObjectError):
@@ -1309,6 +1351,7 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create an SdssForest
         test_obj = SdssForest(**kwargs_sdss_forest)
+        test_obj.rebin()
         self.assert_get_data(test_obj)
 
     def test_sdss_forest_get_header(self):
@@ -1318,12 +1361,14 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create an SdssForest
         test_obj = SdssForest(**kwargs_sdss_forest)
+        test_obj.rebin()
 
         # get header and test
         self.assert_get_header(test_obj)
 
         # create a second SdssForest and coadd it to the first
         test_obj_other = SdssForest(**kwargs_sdss_forest2)
+        test_obj_other.rebin()
         test_obj.coadd(test_obj_other)
 
         # get header and test
@@ -1349,6 +1394,7 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a SdssPk1dForest
         test_obj = SdssPk1dForest(**kwargs_sdss_pk1d_forest)
+        test_obj.rebin()
         self.assertTrue(isinstance(test_obj, SdssPk1dForest))
         self.assertTrue(isinstance(test_obj, SdssForest))
         self.assertTrue(isinstance(test_obj, Pk1dForest))
@@ -1360,6 +1406,7 @@ class AstronomicalObjectTest(AbstractTest):
             "test_variable": "test",
         })
         test_obj = SdssPk1dForest(**kwargs)
+        test_obj.rebin()
         self.assert_forest_object(test_obj, kwargs_sdss_pk1d_forest_rebin)
 
         # create a SdssPk1dForest with missing SdssForest variables
@@ -1427,9 +1474,11 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create a SdssPk1dForest
         test_obj = SdssPk1dForest(**kwargs_sdss_pk1d_forest)
+        test_obj.rebin()
 
         # create a second SdssPk1dForest
         test_obj_other = SdssPk1dForest(**kwargs_sdss_pk1d_forest2)
+        test_obj_other.rebin()
 
         # coadd them
         test_obj.coadd(test_obj_other)
@@ -1439,6 +1488,7 @@ class AstronomicalObjectTest(AbstractTest):
         kwargs = kwargs_sdss_pk1d_forest2.copy()
         kwargs["thingid"] = 999
         test_obj_other = SdssPk1dForest(**kwargs)
+        test_obj_other.rebin()
 
         # coadding them should raise an error
         with self.assertRaises(AstronomicalObjectError):
@@ -1462,12 +1512,14 @@ class AstronomicalObjectTest(AbstractTest):
 
         # create an SdssPk1dForest
         test_obj = SdssPk1dForest(**kwargs_sdss_pk1d_forest)
+        test_obj.rebin()
 
         # get header and test
         self.assert_get_header(test_obj)
 
         # create a second SdssPk1dForest and coadd it to the first
         test_obj_other = SdssPk1dForest(**kwargs_sdss_pk1d_forest2)
+        test_obj_other.rebin()
         test_obj.coadd(test_obj_other)
 
         # get header and test

--- a/py/picca/tests/delta_extraction/test_utils.py
+++ b/py/picca/tests/delta_extraction/test_utils.py
@@ -88,6 +88,7 @@ kwargs1 = {
     "mjd": 0,
 }
 forest1 = SdssForest(**kwargs1)
+forest1.rebin()
 # forest 1 properties
 assert np.allclose(forest1.flux, np.ones_like(forest1_log_lambda))
 assert np.allclose(forest1.log_lambda, forest1_log_lambda)
@@ -114,6 +115,7 @@ kwargs2 = {
     "mjd": 0,
 }
 forest2 = SdssForest(**kwargs2)
+forest2.rebin()
 # forest 2 properties
 assert np.allclose(forest2.flux, np.ones_like(forest2_log_lambda))
 assert np.allclose(forest2.log_lambda, forest2_log_lambda)
@@ -140,6 +142,7 @@ kwargs3 = {
     "mjd": 0,
 }
 forest3 = SdssForest(**kwargs3)
+forest3.rebin()
 # forest 2 properties
 assert np.allclose(forest3.flux, np.ones_like(forest3_log_lambda))
 assert np.allclose(forest3.log_lambda, forest3_log_lambda)


### PR DESCRIPTION
This intends to fix an issue related with multiple inheritance. We need all the variables to be properly initialized before rebinning and the best way to deal with this is to run rebinning after initialisation is complete.