### PR TITLE
Change coverage treatment

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,28 @@
+# .coveragerc to control coverage.py
+[run]
+branch = True
+omit = py/picca/tests/*
+
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+    # Don't complain about abstract methods, they aren't run:
+    @(abc\.)?abstractmethod
+
+ignore_errors = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 # .coveragerc to control coverage.py
 [run]
-branch = False
+branch = True
 omit = py/picca/tests/*
 
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 # .coveragerc to control coverage.py
 [run]
-branch = True
+branch = False
 omit = py/picca/tests/*
 
 

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Test with pytest
       timeout-minutes: 30
       run: |
-          pytest --capture=tee-sys --cov --cov-report xml .
+          pytest --capture=tee-sys --cov --cov-report xml --cov-config=.coveragerc .
 
     # allow connecting to the github action run via ssh if [ci debug] has been in the commit msg
     - name: Debug with tmate


### PR DESCRIPTION
added a .coveragerc file to configure test coverage estimation. Some changes compared to previous measurement:
- we exclude the actual tests from the measurement: if code is added there, but never executed we are fine with it (reduces number of lines in the tests by ~3000, number of covered lines is reduced by ~100 as test code had near complete coverage, so  coverage decrease is expected with this merge, 68% -> 61%)
- added branch coverage: coverage will track if only one branch of e.g. an if statement (i.e. the statement was never True or never False in the tests) is ever executed and complain in that case (this further reduces coverage, but not by much 61% -> 58%)
- added some default things to ignore, e.g. if something gets deactivated intentionally via `if 0:` this is not counted as missing coverage
- added the `no cover` pragma that allows disabling coverage tests for individual lines e.g. if it is known at the time of writing that a branch will never be executed (e.g. while loops that only exit via break)