### PR TITLE
copy existing logs to prevent accidental deletion

### DIFF
--- a/py/picca/delta_extraction/config.py
+++ b/py/picca/delta_extraction/config.py
@@ -525,6 +525,10 @@ class Config:
         usages. The file is saved under the name .config.ini and in
         the self.out_dir folder
         """
-        config_file = open(f"{self.out_dir}/.config.ini", 'w')
+        outname=f"{self.out_dir}/.config.ini"
+        if os.path.exists(outname):
+            newname=f"{outname}.{os.path.getmtime(outname)}"
+            os.path.rename(outname, newname)
+        config_file = open(outname, 'w')
         self.config.write(config_file)
         config_file.close()

--- a/py/picca/delta_extraction/utils.py
+++ b/py/picca/delta_extraction/utils.py
@@ -2,6 +2,7 @@
 package"""
 import importlib
 import logging
+import os
 
 from scipy.constants import speed_of_light as speed_light
 
@@ -195,6 +196,9 @@ def setup_logger(logging_level_console=logging.DEBUG, log_file=None,
 
     # create file handler which logs messages to file
     if log_file is not None:
+        if os.path.exists(log_file):
+            newfilename = f'{log_file}.{os.path.getmtime(log_file)}'
+            os.rename(log_file, newfilename)
         file_handler = logging.FileHandler(log_file, mode="w")
         file_handler.setLevel(logging_level_file)
         file_handler.setFormatter(formatter)


### PR DESCRIPTION
currently, if picca_delta_extraction is run in overwrite mode (not sure if this is True even without), any preexisting log is overwritten early on. This PR will rename previous logs based on their modification timestamp instead.