### PR TITLE
Add constant weights for true cont

### DIFF
--- a/py/picca/delta_extraction/expected_fluxes/true_continuum.py
+++ b/py/picca/delta_extraction/expected_fluxes/true_continuum.py
@@ -343,7 +343,6 @@ class TrueContinuum(ExpectedFlux):
                 continue
             # get the variance functions
             if self.use_constant_weight:
-                var_lss = np.ones_like(forest.log_lambda)
                 weights = np.ones_like(forest.log_lambda)
             else:
                 var_lss = self.get_var_lss(forest.log_lambda)

--- a/py/picca/delta_extraction/expected_fluxes/true_continuum.py
+++ b/py/picca/delta_extraction/expected_fluxes/true_continuum.py
@@ -175,8 +175,8 @@ class TrueContinuum(ExpectedFlux):
         forests: List of Forest
         A list of Forest from which to compute the deltas.
         """
-        mean_cont = np.zeros_like(Forest.log_lambda_rest_frame_grid.size)
-        mean_cont_weight = np.zeros_like(Forest.log_lambda_rest_frame_grid.size)
+        mean_cont = np.zeros_like(Forest.log_lambda_rest_frame_grid)
+        mean_cont_weight = np.zeros_like(Forest.log_lambda_rest_frame_grid)
 
         for forest in forests:
             if forest.bad_continuum_reason is not None:

--- a/py/picca/delta_extraction/expected_fluxes/true_continuum.py
+++ b/py/picca/delta_extraction/expected_fluxes/true_continuum.py
@@ -18,7 +18,7 @@ from picca.delta_extraction.utils import find_bins
 
 accepted_options = ["input directory", "iter out prefix",
                     "num processors", "out dir",
-                    "raw statistics file"]
+                    "raw statistics file","use constant weight"]
 
 defaults = {
     "iter out prefix": "delta_attributes",

--- a/py/picca/delta_extraction/expected_fluxes/true_continuum.py
+++ b/py/picca/delta_extraction/expected_fluxes/true_continuum.py
@@ -344,6 +344,7 @@ class TrueContinuum(ExpectedFlux):
             # get the variance functions
             if self.use_constant_weight:
                 weights = np.ones_like(forest.log_lambda)
+                mean_expected_flux = forest.continuum
             else:
                 var_lss = self.get_var_lss(forest.log_lambda)
 


### PR DESCRIPTION
This adds the option to use constant weights for the true continuum analysis, which works without the raw statistics file. Also fixes a bug in the current true cont calculation.