### PR TITLE
Add option to interpolate the blinding template for non-standard binning

### DIFF
--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -268,14 +268,15 @@ def main(cmdargs):
             raise ValueError("Blinding strategy 'corr_yshift' requires"
                              " argument --blind_corr_type.")
 
+        # Check type of correlation and get size and regular binning
         if args.blind_corr_type in ['lyaxlya', 'lyaxlyb']:
             corr_size = 2500
-            rp_interp_grid = np.arange(2., 202., 4.)
-            rt_interp_grid = np.arange(2., 202., 4.)
+            rp_interp_grid = np.arange(2., 202., 4)
+            rt_interp_grid = np.arange(2., 202., 4)
         elif args.blind_corr_type in ['qsoxlya', 'qsoxlyb']:
             corr_size = 5000
-            rp_interp_grid = np.arange(-197.99, 202.01, 4.)
-            rt_interp_grid = np.arange(2., 202, 4.)
+            rp_interp_grid = np.arange(-197.99, 202.01, 4)
+            rt_interp_grid = np.arange(2., 202, 4)
         else:
             raise ValueError("Unknown correlation type: {}".format(args.blind_corr_type))
 
@@ -300,6 +301,7 @@ def main(cmdargs):
             hex_diff = np.array(blinding_file['blinding'][args.blind_corr_type]).astype(str)
             diff_grid = np.array([float.fromhex(x) for x in hex_diff])
 
+            # Interpolate the blinding template on the regular grid
             rt_grid, rp_grid = np.meshgrid(rt_interp_grid, rp_interp_grid)
             interp = scipy.interpolate.RectBivariateSpline(
                     rp_grid, rt_grid,

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -300,10 +300,9 @@ def main(cmdargs):
             diff = diff_grid
         else:
             # Interpolate the blinding template on the regular grid
-            rt_grid, rp_grid = np.meshgrid(rt_interp_grid, rp_interp_grid)
             interp = scipy.interpolate.RectBivariateSpline(
-                    rp_grid, rt_grid,
-                    diff_grid.reshape(num_bins_r_par, num_bins_r_trans), kx=3, ky=3)
+                    rp_interp_grid, rt_interp_grid,
+                    diff_grid.reshape(len(rp_interp_grid), len(rt_interp_grid)), kx=3, ky=3)
             diff = interp.ev(r_par, r_trans)
 
         # Check that the shapes match

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -284,23 +284,21 @@ def main(cmdargs):
             # Read the blinding file and get the right template
             blinding_filename = ('/global/cfs/projectdirs/desi/science/lya/y1-kp6/'
                                  'blinding/y1_blinding_v1.2_standard_29_03_2022.h5')
-            if not os.path.isfile(blinding_filename):
-                raise RuntimeError("Missing blinding file. Make sure you are running at"
-                                   " NERSC or contact picca developers")
-            blinding_file = h5py.File(blinding_filename, 'r')
-            hex_diff = np.array(blinding_file['blinding'][args.blind_corr_type]).astype(str)
-            diff = np.array([float.fromhex(x) for x in hex_diff])
         else:
             # Read the regular grid blinding file and get the right template
             blinding_filename = ('/global/cfs/projectdirs/desi/science/lya/y1-kp6/'
                                  'blinding/y1_blinding_v1.2_regular_grid_29_03_2022.h5')
-            if not os.path.isfile(blinding_filename):
-                raise RuntimeError("Missing blinding file. Make sure you are running at"
-                                   " NERSC or contact picca developers")
-            blinding_file = h5py.File(blinding_filename, 'r')
-            hex_diff = np.array(blinding_file['blinding'][args.blind_corr_type]).astype(str)
-            diff_grid = np.array([float.fromhex(x) for x in hex_diff])
 
+        if not os.path.isfile(blinding_filename):
+            raise RuntimeError("Missing blinding file. Make sure you are running at"
+                               " NERSC or contact picca developers")
+        blinding_file = h5py.File(blinding_filename, 'r')
+        hex_diff = np.array(blinding_file['blinding'][args.blind_corr_type]).astype(str)
+        diff_grid = np.array([float.fromhex(x) for x in hex_diff])
+
+        if corr_size == len(xi):
+            diff = diff_grid
+        else:
             # Interpolate the blinding template on the regular grid
             rt_grid, rp_grid = np.meshgrid(rt_interp_grid, rp_interp_grid)
             interp = scipy.interpolate.RectBivariateSpline(


### PR DESCRIPTION
I added a new option in picca_export to interpolate the blinding template from a precomputed regular grid (now available on NERSC). This option is automatically activated for non-standard binning (i.e. 50 bins of 4 Mpc/h in rp and rt for the auto and double the rp bins for the cross) of the correlation. I have not tested this yet.

I also updated the default blinding template from v1 to v1.2. The new file has the same seed for blinding ap/at, but uses the new default version of vega where we do not allow metal correlations to have ap/at different from 1. This has a negligible impact on the blinding template, but it gets picked up in the total chisq which is used as a safety check in the blinding script. Therefore, an update was in order.