### PR TITLE
add a pyproject file to have gitpython as build-dep

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -35,6 +35,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install wheel pytest pytest-cov coveralls
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    # TODO: the section below can be removed if the compile step is fixed otherwise
+    - name: Reinstall fitsio to ensure the numpy version during compilation matches the one at runtime
+      run: |
+        pip uninstall fitsio -y
+        pip cache purge
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Install picca
       run: pip install -e .
     - name: Test with pytest

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -35,12 +35,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install wheel pytest pytest-cov coveralls
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    # TODO: the section below can be removed if the compile step is fixed otherwise
-    - name: Reinstall fitsio to ensure the numpy version during compilation matches the one at runtime
-      run: |
-        pip uninstall fitsio -y
-        pip cache purge
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Install picca
       run: pip install -e .
     - name: Test with pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 56.2.0", "gitpython >= 3.1.18", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 56.2.0", "gitpython >= 3.1.18", "wheel", "numpy >= 1.20.3"]
+requires = ["setuptools >= 56.2.0", "gitpython >= 3.1.18", "wheel"]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 56.2.0", "gitpython >= 3.1.18", "wheel"]
+requires = ["setuptools >= 56.2.0", "gitpython >= 3.1.18", "wheel", "numpy >= 1.20.3"]
 build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
This PR adds a config file to allow installing picca in a "raw" python installation without previous install of gitpython. Before this is merged a simple "pip install ." results in:
```Processing /home/m/Michael.Walther/Dokumente/codes/igmhub/picca
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/m/Michael.Walther/Dokumente/codes/igmhub/picca/setup.py", line 4, in <module>
          import git
      ModuleNotFoundError: No module named 'git'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

after a merge it will just install.