### PR TITLE
Fix z resolution coadd

### DIFF
--- a/py/picca/delta_extraction/astronomical_objects/desi_pk1d_forest.py
+++ b/py/picca/delta_extraction/astronomical_objects/desi_pk1d_forest.py
@@ -103,11 +103,11 @@ class DesiPk1dForest(DesiForest, Pk1dForest):
                 smallershape = np.min([self.resolution_matrix.shape[0],other.resolution_matrix.shape[0]])
                 shapediff = largershape - smallershape
                 if self.resolution_matrix.shape[0]==smallershape:
-                    self.resolution_matrix = np.append(np.zeros(shapediff//2,self.resolution_matrix.shape[1]),self.resolution_matrix,axis=0)
-                    self.resolution_matrix = np.append(self.resolution_matrix,np.zeros(shapediff//2,self.resolution_matrix.shape[1]),axis=0)
+                    self.resolution_matrix = np.append(np.zeros([shapediff//2,self.resolution_matrix.shape[1]]),self.resolution_matrix,axis=0)
+                    self.resolution_matrix = np.append(self.resolution_matrix,np.zeros([shapediff//2,self.resolution_matrix.shape[1]]),axis=0)
                 if other.resolution_matrix.shape[0]==smallershape:
-                    other.resolution_matrix = np.append(np.zeros(shapediff//2,other.resolution_matrix.shape[1]),other.resolution_matrix,axis=0)
-                    other.resolution_matrix = np.append(other.resolution_matrix,np.zeros(shapediff//2,other.resolution_matrix.shape[1]),axis=0)
+                    other.resolution_matrix = np.append(np.zeros([shapediff//2,other.resolution_matrix.shape[1]]),other.resolution_matrix,axis=0)
+                    other.resolution_matrix = np.append(other.resolution_matrix,np.zeros([shapediff//2,other.resolution_matrix.shape[1]]),axis=0)
 
             self.resolution_matrix = np.append(self.resolution_matrix,
                                                other.resolution_matrix,

--- a/py/picca/delta_extraction/astronomical_objects/desi_pk1d_forest.py
+++ b/py/picca/delta_extraction/astronomical_objects/desi_pk1d_forest.py
@@ -98,6 +98,17 @@ class DesiPk1dForest(DesiForest, Pk1dForest):
                 f"{type(other)}")
 
         if other.resolution_matrix.size > 0 and self.resolution_matrix.size > 0:
+            if self.resolution_matrix.shape[0]!=other.resolution_matrix.shape[0]:
+                largershape = np.max([self.resolution_matrix.shape[0],other.resolution_matrix.shape[0]])
+                smallershape = np.min([self.resolution_matrix.shape[0],other.resolution_matrix.shape[0]])
+                shapediff = largershape - smallershape
+                if self.resolution_matrix.shape[0]==smallershape:
+                    self.resolution_matrix = np.append(np.zeros(shapediff//2,self.resolution_matrix.shape[1]),self.resolution_matrix,axis=0)
+                    self.resolution_matrix = np.append(self.resolution_matrix,np.zeros(shapediff//2,self.resolution_matrix.shape[1]),axis=0)
+                if other.resolution_matrix.shape[0]==smallershape:
+                    other.resolution_matrix = np.append(np.zeros(shapediff//2,other.resolution_matrix.shape[1]),other.resolution_matrix,axis=0)
+                    other.resolution_matrix = np.append(other.resolution_matrix,np.zeros(shapediff//2,other.resolution_matrix.shape[1]),axis=0)
+
             self.resolution_matrix = np.append(self.resolution_matrix,
                                                other.resolution_matrix,
                                                axis=1)

--- a/py/picca/delta_extraction/data_catalogues/desi_healpix.py
+++ b/py/picca/delta_extraction/data_catalogues/desi_healpix.py
@@ -160,6 +160,8 @@ class DesiHealpix(DesiData):
             with context.Pool(processes=self.num_processors) as pool:
 
                 pool.starmap(self.read_file, arguments)
+            for key,forest in forests_by_targetid.items():
+                forest.consistency_check()
         else:
             forests_by_targetid = {}
             for (index,
@@ -309,7 +311,7 @@ class DesiHealpix(DesiData):
                     "z": row['Z'],
                 }
                 args["log_lambda"] = np.log10(spec['WAVELENGTH'])
-                
+
                 if self.analysis_type == "BAO 3D":
                     forest = DesiForest(**args)
                 elif self.analysis_type == "PK 1D":

--- a/py/picca/delta_extraction/data_catalogues/desi_healpix.py
+++ b/py/picca/delta_extraction/data_catalogues/desi_healpix.py
@@ -161,6 +161,7 @@ class DesiHealpix(DesiData):
 
                 pool.starmap(self.read_file, arguments)
             for key,forest in forests_by_targetid.items():
+                #TODO: the following just does the consistency checking again, to avoid mask_fields not being populated. In the long run an alternative way of running the multiprocessing is envisioned which would be more stable, see discussion in PRs 879 and 883
                 forest.consistency_check()
         else:
             forests_by_targetid = {}

--- a/py/picca/delta_extraction/data_catalogues/desisim_mocks.py
+++ b/py/picca/delta_extraction/data_catalogues/desisim_mocks.py
@@ -116,6 +116,7 @@ class DesisimMocks(DesiHealpix):
 
                 pool.starmap(self.read_file, arguments)
             for key,forest in forests_by_targetid.items():
+                #TODO: the following just does the consistency checking again, to avoid mask_fields not being populated. In the long run an alternative way of running the multiprocessing is envisioned which would be more stable, see discussion in PRs 879 and 883
                 forest.consistency_check()
         else:
             forests_by_targetid = {}

--- a/py/picca/delta_extraction/data_catalogues/desisim_mocks.py
+++ b/py/picca/delta_extraction/data_catalogues/desisim_mocks.py
@@ -115,6 +115,8 @@ class DesisimMocks(DesiHealpix):
             with context.Pool(processes=self.num_processors) as pool:
 
                 pool.starmap(self.read_file, arguments)
+            for key,forest in forests_by_targetid.items():
+                forest.consistency_check()
         else:
             forests_by_targetid = {}
             for (index,


### PR DESCRIPTION
This PR will allow coadding of resolution matrices of different shape (i.e. R- and Z- in current ohio-mocks which wouldn't run anymore without this fix).
To do so the reso matrix with less diagonals is padded with zeros on both sides to match the one with more diagonals.
@corentinravoux will do some tests.