### PR TITLE
Var stats fitter change

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,7 +18,7 @@ jobs:
         sudo apt-get -y install libbz2-dev
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install pylint
+        pip install pylint==2.12.2
     - name: This path
       run: |
         ls

--- a/py/picca/delta_extraction/expected_fluxes/dr16_expected_flux.py
+++ b/py/picca/delta_extraction/expected_fluxes/dr16_expected_flux.py
@@ -14,8 +14,8 @@ from picca.delta_extraction.expected_flux import ExpectedFlux
 from picca.delta_extraction.utils import find_bins
 
 accepted_options = [
-    "iter out prefix", "limit eta", "limit var lss", "num bins variance",
-    "num iterations", "num processors", "order", "out dir",
+    "iter out prefix", "limit eta", "limit var lss", "min num qso in fit",
+    "num bins variance", "num iterations", "num processors", "order", "out dir",
     "use constant weight", "use ivar as weight"
 ]
 
@@ -25,6 +25,7 @@ defaults = {
     "limit var lss": (0., 0.3),
     "num bins variance": 20,
     "num iterations": 5,
+    "min num qso in fit": 100,
     "order": 1,
     "use constant weight": False,
     "use ivar as weight": False,
@@ -149,6 +150,7 @@ class Dr16ExpectedFlux(ExpectedFlux):
         self.iter_out_prefix = None
         self.limit_eta = None
         self.limit_var_lss = None
+        self.min_qso_in_fit = None
         self.num_bins_variance = None
         self.num_iterations = None
         self.order = None
@@ -338,6 +340,12 @@ class Dr16ExpectedFlux(ExpectedFlux):
         else:
             var_lss_max = float(limit_var_lss[1])
         self.limit_var_lss = (var_lss_min, var_lss_max)
+
+        self.min_qso_in_fit = config.getint("min qso in fit")
+        if self.min_qso_in_fit is None:
+            raise ExpectedFluxError(
+                "Missing argument 'min qso in fit' required by Dr16ExpectedFlux"
+            )
 
         self.num_bins_variance = config.getint("num bins variance")
         if self.num_bins_variance is None:
@@ -761,7 +769,7 @@ class Dr16ExpectedFlux(ExpectedFlux):
                 weights = var2_delta[index * num_var_bins:(index + 1) *
                                      num_var_bins]
                 w = num_qso[index * num_var_bins:(index + 1) *
-                            num_var_bins] > 100
+                            num_var_bins] > self.min_qso_in_fit
                 return np.sum(chi2_contribution[w]**2 / weights[w])
 
             minimizer = iminuit.Minuit(chi2,

--- a/py/picca/delta_extraction/expected_fluxes/dr16_expected_flux.py
+++ b/py/picca/delta_extraction/expected_fluxes/dr16_expected_flux.py
@@ -150,7 +150,7 @@ class Dr16ExpectedFlux(ExpectedFlux):
         self.iter_out_prefix = None
         self.limit_eta = None
         self.limit_var_lss = None
-        self.min_qso_in_fit = None
+        self.min_num_qso_in_fit = None
         self.num_bins_variance = None
         self.num_iterations = None
         self.order = None
@@ -341,8 +341,8 @@ class Dr16ExpectedFlux(ExpectedFlux):
             var_lss_max = float(limit_var_lss[1])
         self.limit_var_lss = (var_lss_min, var_lss_max)
 
-        self.min_qso_in_fit = config.getint("min qso in fit")
-        if self.min_qso_in_fit is None:
+        self.min_num_qso_in_fit = config.getint("min num qso in fit")
+        if self.min_num_qso_in_fit is None:
             raise ExpectedFluxError(
                 "Missing argument 'min qso in fit' required by Dr16ExpectedFlux"
             )
@@ -769,7 +769,7 @@ class Dr16ExpectedFlux(ExpectedFlux):
                 weights = var2_delta[index * num_var_bins:(index + 1) *
                                      num_var_bins]
                 w = num_qso[index * num_var_bins:(index + 1) *
-                            num_var_bins] > self.min_qso_in_fit
+                            num_var_bins] > self.min_num_qso_in_fit
                 return np.sum(chi2_contribution[w]**2 / weights[w])
 
             minimizer = iminuit.Minuit(chi2,

--- a/py/picca/tests/delta_extraction/data/.config.ini
+++ b/py/picca/tests/delta_extraction/data/.config.ini
@@ -55,7 +55,7 @@ use constant weight = False
 use ivar as weight = False
 out dir = /Users/iperezra/software/picca/py/picca/tests/delta_extraction/results/config_tests/
 num processors = 1
-
+min num qso in fit = 100
 
 [correction arguments 0]
 filename = /Users/iperezra/software/picca/py/picca/tests/delta_extraction/data/delta_attributes.fits.gz


### PR DESCRIPTION
This PR basically converts the minimum number of quasars participating in a bin of wavelength and pipeline variance for it to be considered in the fit of eta, var_lss and fudge