### PR TITLE
fixed installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,21 @@ This package contains tools used for the analysis of the Lyman-alpha forest samp
 The current reference is du Mas des Bourboux et al. 2020 (https://arxiv.org/abs/2007.08995).
 
 ## Installation
-
-download
-```bash
+We recommend to create a clean environment:
+```
+conda create -n my_picca_env python==version
+conda activate my_picca_env
+```
+then download
+```
 git clone https://github.com/igmhub/picca.git
 ```
-
 add to your bashrc
-```bash
+```
 export PICCA_BASE=<path to your picca>
 ```
-
 and finally run
-```bash
+```
 pip install -e .
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,16 +24,10 @@ add to your bashrc
 export PICCA_BASE=<path to your picca>
 ```
 
-then make sure you have all required modules by running
-```bash
-pip install -r requirements.txt --user
-```
-
 and finally run
 ```bash
-python setup.py install --user
+pip install -e .
 ```
-(assuming you run as user; for a system-wide install omit `--user` option).
 
 Alternatively, you can just add `picca/py/` to your `PYTHONPATH`.
 

--- a/README.md
+++ b/README.md
@@ -13,25 +13,51 @@ This package contains tools used for the analysis of the Lyman-alpha forest samp
 The current reference is du Mas des Bourboux et al. 2020 (https://arxiv.org/abs/2007.08995).
 
 ## Installation
-We recommend to create a clean environment:
+First, create a clean environment:
 ```
 conda create -n my_picca_env python==version
 conda activate my_picca_env
 ```
-then download
+If you already have an environment, you just need to activate it.
+After you have the environment, you can install picca with:
+```
+pip install picca
+```
+If you are a developer, or want the most recent version of picca, you can download and install manually:
 ```
 git clone https://github.com/igmhub/picca.git
+cd picca
+pip install -e .
 ```
-add to your bashrc
+Optionally, you can add the path to picca to your bashrc:
 ```
 export PICCA_BASE=<path to your picca>
 ```
-and finally run
-```
-pip install -e .
-```
+Or you can add `picca/py/` to your `PYTHONPATH`. Both of these are optional and picca will work without them.
 
-Alternatively, you can just add `picca/py/` to your `PYTHONPATH`.
+If you are at working at NERSC, we recommend to keep everything clean by adding a function like this in your bashrc:
+```
+picca_env () {
+    module load python
+    conda activate my_picca_env
+}
+```
+Whenever you need picca just write:
+```
+picca_env
+```
+This is cleaner than directly adding the commands to the bashrc file, and avoids potential issues with the transition to Perlmutter.
+
+If you want to compute models for the correlations computed with picca, or you want to fit these correlations, see https://github.com/andreicuceu/vega.
+
+If you are running MPI code (only needed for some tasks in fitter2), see https://docs.nersc.gov/development/languages/python/parallel-python/#mpi4py-in-your-custom-conda-environment. If want to run the PolyChord sampler for fitter2, see https://github.com/andreicuceu/fitter2_tutorial.
+
+If you need to run the "picca_compute_pk_pksb.py" script you will also need to install the following packages:
+```
+pip install camb
+pip install cython
+pip install nbodykit
+```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This is cleaner than directly adding the commands to the bashrc file, and avoids
 
 If you want to compute models for the correlations computed with picca, or you want to fit these correlations, see https://github.com/andreicuceu/vega.
 
-If you are running MPI code (only needed for some tasks in fitter2), see https://docs.nersc.gov/development/languages/python/parallel-python/#mpi4py-in-your-custom-conda-environment. If want to run the PolyChord sampler for fitter2, see https://github.com/andreicuceu/fitter2_tutorial.
+If you are running MPI code (only needed for some tasks in fitter2), see https://docs.nersc.gov/development/languages/python/parallel-python/#mpi4py-in-your-custom-conda-environment. If want to run the PolyChord sampler for fitter2, see https://github.com/andreicuceu/fitter2_tutorial. Note that fitter2 is deprecated, and will be removed in the future.
 
 If you need to run the "picca_compute_pk_pksb.py" script you will also need to install the following packages:
 ```

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,3 +1,0 @@
-camb>=1.1.2
-cython>=0.29.21
-nbodykit>=0.3.12

--- a/requirements-mpi.txt
+++ b/requirements-mpi.txt
@@ -1,2 +1,0 @@
-mpi4py>=3.0.3
-pypolychord==1.16


### PR DESCRIPTION
Removes the `--user` from the picca installation instructions. Use `pip install -e .` instead