### PR TITLE
Faster true cont

### DIFF
--- a/py/picca/tests/delta_extraction/expected_flux_tests.py
+++ b/py/picca/tests/delta_extraction/expected_flux_tests.py
@@ -1307,7 +1307,7 @@ class ExpectedFluxTest(AbstractTest):
         f = open(out_file, "w")
         f.write("# thingid cont[0] ... cont[N]\n")
         for forest in data.forests:
-            expected_flux.read_true_continuum([forest])
+            expected_flux.read_true_continuum_one_healpix([forest])
             f.write(f"{forest.los_id} ")
             if forest.continuum is not None:
                 for item in forest.continuum:
@@ -1387,7 +1387,7 @@ class ExpectedFluxTest(AbstractTest):
         f = open(out_file, "w")
         f.write("# thingid cont[0] ... cont[N]\n")
         for forest in data.forests:
-            expected_flux.read_true_continuum([forest])
+            expected_flux.read_true_continuum_one_healpix([forest])
             f.write(f"{forest.los_id} ")
             if forest.continuum is not None:
                 for item in forest.continuum:
@@ -1666,8 +1666,7 @@ class ExpectedFluxTest(AbstractTest):
         expected_flux = TrueContinuum(config["expected flux"])
 
         # compute the forest continua
-        for forest in data.forests:
-            expected_flux.read_true_continuum([forest])
+        data.forests = expected_flux.read_all_true_continua(data.forests)
 
         # run populate_los_ids
         expected_flux.populate_los_ids(data.forests)


### PR DESCRIPTION
True continuum analysis reads files one healpix at a time, which should reduce io friction and speed up delta_extraction