### PR TITLE
Update bal_mask.py

### DIFF
--- a/py/picca/delta_extraction/masks/bal_mask.py
+++ b/py/picca/delta_extraction/masks/bal_mask.py
@@ -21,6 +21,8 @@ accepted_options = ["bal index type", "filename", "los_id name"]
 # Wavelengths in Angstroms
 lines = {
     "lCIV": 1549,
+    "lSiIV1": 1394,
+    "lSiIV2": 1403,
     "lNV": 1240.81,
     "lLya": 1216.1,
     "lCIII": 1175,


### PR DESCRIPTION
Adding Si IV lines to mask in BAL quasars. This affects the first side band region, i.e. not Lya forest.