### PR TITLE
Masking optimizations and parallelization

### DIFF
--- a/py/picca/delta_extraction/config.py
+++ b/py/picca/delta_extraction/config.py
@@ -340,7 +340,7 @@ class Config:
         # add output directory
         section["out dir"] = self.out_dir
         if "num processors" in accepted_options and "num processors" not in section:
-            section["num processors"] = self.num_processors
+            section["num processors"] = str(self.num_processors)
 
         # finally add the information to self.data
         self.data = (DataType, section)
@@ -408,7 +408,7 @@ class Config:
             section["out dir"] = self.out_dir
         if ("num processors" in accepted_options and
                 "num processors" not in section):  # pragma: no branch
-            section["num processors"] = self.num_processors
+            section["num processors"] = str(self.num_processors)
         # finally add the information to self.continua
         self.expected_flux = (ExpectedFluxType, section)
 
@@ -473,7 +473,7 @@ class Config:
                 "In section 'logging level file' in section [general]")
         self.logging_level_file = self.logging_level_file.upper()
 
-        self.num_processors = section.get("num processors")
+        self.num_processors = section.getint("num processors")
         # this should never be true as the general section is loaded in the
         # default dictionary
         if self.num_processors is None:  # pragma: no cover

--- a/py/picca/delta_extraction/masks/bal_mask.py
+++ b/py/picca/delta_extraction/masks/bal_mask.py
@@ -2,7 +2,6 @@
 masking of DLAs"""
 import logging
 
-from astropy.table import Table
 import fitsio
 import numpy as np
 
@@ -34,6 +33,8 @@ lines = {
     "lOI": 1039
 }
 
+# Numpy arrays are faster to modifty
+lines_np = np.array(list(lines.values()), dtype=float)
 
 class BalMask(Mask):
     """Class to mask BALs
@@ -51,6 +52,9 @@ class BalMask(Mask):
     bal_index_type: str
     BAL index type, choose either 'ai' or 'bi'. This will set which velocity
     the  BAL mask uses.
+
+    velocity_list: list of str
+    List of column names for minimum and maximum velocities respectively.
 
     cat: dict
     Dictionary with the BAL catalogue
@@ -119,6 +123,8 @@ class BalMask(Mask):
                 "of 'ai' or 'bi'. Found "
                 f"{self.bal_index_type}")
 
+        self.velocity_list = columns_list[1:]
+
         self.logger.progress(f"Reading BAL catalog from: {filename}")
 
         try:
@@ -157,50 +163,40 @@ class BalMask(Mask):
         los_id_name: str
         Name of the line-of-sight id
         """
-        if self.bal_index_type == 'bi':
-            velocity_list = ['VMIN_CIV_2000', 'VMAX_CIV_2000']
-        else:  # AI, the default
-            velocity_list = ['VMIN_CIV_450', 'VMAX_CIV_450']
-
-        mask_rest_frame_bal = Table(names=[
-            'log_lambda_min', 'log_lambda_max', 'lambda_min', 'lambda_max'
-        ],
-                                    dtype=['f4', 'f4', 'f4', 'f4'])
-        min_velocities = []  # list of minimum velocities
-        max_velocities = []  # list of maximum velocities
-
         # Match thing_id of object to BAL catalog index
-        match_index = np.where(self.cat[los_id_name] == los_id)[0][0]
+        # Will there be duplicates or only one index?
+        match_index = np.where(self.cat[los_id_name] == los_id)[0]
 
         # Store the min/max velocity pairs from the BAL catalog
-        for col in velocity_list:
-            if col.find('VMIN') == 0:
-                velocity_list = self.cat[col]
-                for vel in velocity_list[match_index]:
-                    if vel > 0:
-                        min_velocities.append(vel)
-            else:
-                velocity_list = self.cat[col]
-                for vel in velocity_list[match_index]:
-                    if vel > 0:
-                        max_velocities.append(vel)
+        colmin = self.cat[self.velocity_list[0]]
+        colmax = self.cat[self.velocity_list[1]]
+        # np.array of minimum velocities
+        min_velocities = np.array(colmin[match_index], dtype=float)
+        # np.array of maximum velocities
+        max_velocities = np.array(colmax[match_index], dtype=float)
+        # Remove non-positive velocity rows
+        w = (min_velocities>0) & (max_velocities>0)
+        min_velocities = min_velocities[w]
+        max_velocities = max_velocities[w]
+
+        nvelocities = w.sum()
+        nlines = lines_np.size
+        mask_rest_frame_bal = np.empty(nvelocities * nlines,
+            dtype=[('log_lambda_min', 'f8'), ('log_lambda_max', 'f8'),
+            ('lambda_min', 'f8'), ('lambda_max', 'f8')])
 
         # Calculate mask width for each velocity pair, for each emission line
-        for min_vel, max_vel in zip(min_velocities, max_velocities):
-            for line in lines.values():
-                # This might be  bit confusing, since BAL absorption is
-                # blueshifted from the emission lines. The “minimum velocity”
-                # corresponds to the red side of the BAL absorption (the larger
-                # wavelength value), and the “maximum velocity” corresponds to
-                # the blue side (the smaller wavelength value).
-                log_lambda_max = np.log10(line * (1 - min_vel / SPEED_LIGHT))
-                log_lambda_min = np.log10(line * (1 - max_vel / SPEED_LIGHT))
-                mask_rest_frame_bal.add_row([
-                    log_lambda_min,
-                    log_lambda_max,
-                    10**log_lambda_min,
-                    10**log_lambda_max,
-                ])
+        # This might be  bit confusing, since BAL absorption is
+        # blueshifted from the emission lines. The “minimum velocity”
+        # corresponds to the red side of the BAL absorption (the larger
+        # wavelength value), and the “maximum velocity” corresponds to
+        # the blue side (the smaller wavelength value).
+        lambda_max = np.outer(lines_np, 1 - min_velocities / SPEED_LIGHT).ravel()
+        lambda_min = np.outer(lines_np, 1 - max_velocities / SPEED_LIGHT).ravel()
+        mask_rest_frame_bal['lambda_min'] = lambda_min
+        mask_rest_frame_bal['lambda_max'] = lambda_max
+        mask_rest_frame_bal['log_lambda_min'] = np.log10(lambda_min)
+        mask_rest_frame_bal['log_lambda_max'] = np.log10(lambda_max)
 
         return mask_rest_frame_bal
 
@@ -218,18 +214,21 @@ class BalMask(Mask):
         MaskError if Forest.wave_solution is not 'log'
         """
         mask_table = self.los_ids.get(forest.los_id)
-        if (mask_table is not None) and len(mask_table) > 0:
+        if (mask_table is None) or len(mask_table) == 0:
+            return
 
-            # find out which pixels to mask
-            w = np.ones(forest.log_lambda.size, dtype=bool)
-            for mask_range in mask_table:
-                rest_frame_log_lambda = forest.log_lambda - np.log10(1. + forest.z)
-                w &= ((rest_frame_log_lambda < mask_range['log_lambda_min']) |
-                      (rest_frame_log_lambda > mask_range['log_lambda_max']))
+        # find out which pixels to mask
+        w = np.ones(forest.log_lambda.size, dtype=bool)
+        rest_frame_log_lambda = forest.log_lambda - np.log10(1. + forest.z)
+        idx1s, idx2s = np.searchsorted(rest_frame_log_lambda,
+                [mask_table['log_lambda_min'], mask_table['log_lambda_max']])
 
-            # do the actual masking
-            for param in Forest.mask_fields:
-                if param in ['resolution_matrix']:
-                    setattr(forest, param, getattr(forest, param)[:, w])
-                else:
-                    setattr(forest, param, getattr(forest, param)[w])
+        for idx1, idx2 in zip(idx1s, idx2s):
+            w[idx1:idx2] = 0
+
+        # do the actual masking
+        for param in Forest.mask_fields:
+            if param in ['resolution_matrix']:
+                setattr(forest, param, getattr(forest, param)[:, w])
+            else:
+                setattr(forest, param, getattr(forest, param)[w])

--- a/py/picca/delta_extraction/masks/lines_mask.py
+++ b/py/picca/delta_extraction/masks/lines_mask.py
@@ -79,17 +79,17 @@ class LinesMask(Mask):
         """
         # find masking array
         w = np.ones(forest.log_lambda.size, dtype=bool)
-        idx1s, idx2s = np.searchsorted(forest.log_lambda,
+        mask_idx_ranges = np.searchsorted(forest.log_lambda,
             [self.mask_obs_frame['log_wave_min'],
-            self.mask_obs_frame['log_wave_max']])
-        for idx1, idx2 in zip(idx1s, idx2s):
+            self.mask_obs_frame['log_wave_max']]).T
+        for idx1, idx2 in mask_idx_ranges:
             w[idx1:idx2] = 0
 
         log_lambda_rest_frame = forest.log_lambda - np.log10(1.0 + forest.z)
-        idx1s, idx2s = np.searchsorted(log_lambda_rest_frame,
+        mask_idx_ranges = np.searchsorted(log_lambda_rest_frame,
             [self.mask_rest_frame['log_wave_min'],
-            self.mask_rest_frame['log_wave_max']])
-        for idx1, idx2 in zip(idx1s, idx2s):
+            self.mask_rest_frame['log_wave_max']]).T
+        for idx1, idx2 in mask_idx_ranges:
             w[idx1:idx2] = 0
 
         # do the actual masking

--- a/py/picca/delta_extraction/masks/lines_mask.py
+++ b/py/picca/delta_extraction/masks/lines_mask.py
@@ -79,13 +79,18 @@ class LinesMask(Mask):
         """
         # find masking array
         w = np.ones(forest.log_lambda.size, dtype=bool)
-        for mask_range in self.mask_obs_frame:
-            w &= ((forest.log_lambda < mask_range['log_wave_min']) |
-                  (forest.log_lambda > mask_range['log_wave_max']))
+        idx1s, idx2s = np.searchsorted(forest.log_lambda,
+            [self.mask_obs_frame['log_wave_min'],
+            self.mask_obs_frame['log_wave_max']])
+        for idx1, idx2 in zip(idx1s, idx2s):
+            w[idx1:idx2] = 0
+
         log_lambda_rest_frame = forest.log_lambda - np.log10(1.0 + forest.z)
-        for mask_range in self.mask_rest_frame:
-            w &= ((log_lambda_rest_frame < mask_range['log_wave_min']) |
-                  (log_lambda_rest_frame > mask_range['log_wave_max']))
+        idx1s, idx2s = np.searchsorted(log_lambda_rest_frame,
+            [self.mask_rest_frame['log_wave_min'],
+            self.mask_rest_frame['log_wave_max']])
+        for idx1, idx2 in zip(idx1s, idx2s):
+            w[idx1:idx2] = 0
 
         # do the actual masking
         for param in Forest.mask_fields:

--- a/py/picca/delta_extraction/survey.py
+++ b/py/picca/delta_extraction/survey.py
@@ -97,6 +97,9 @@ class Survey:
     masks: list of Mask
     Mask corrections to be applied to individual spectra. This includes things
     like absorber mask, DLA mask, ...
+
+    num_processors: int
+    Number of processors to use in parallelization
     """
     def __init__(self):
         """Initialize class instance"""

--- a/py/picca/delta_extraction/survey.py
+++ b/py/picca/delta_extraction/survey.py
@@ -132,7 +132,8 @@ class Survey:
             chunksize = int(len(self.data.forests)/self.num_processors/3)
             chunksize = max(1, chunksize)
             with context.Pool(processes=self.num_processors) as pool:
-                self.data.forests = pool.map(MaskHandler(self.masks), self.data.forests)
+                self.data.forests = pool.map(MaskHandler(self.masks),
+                    self.data.forests, chunksize=chunksize)
         else:
             mask_handler = MaskHandler(self.masks)
             for forest_index, _ in enumerate(self.data.forests):

--- a/py/picca/delta_extraction/survey.py
+++ b/py/picca/delta_extraction/survey.py
@@ -197,7 +197,7 @@ class Survey:
         """
         # load configuration
         self.config = Config(config_file)
-        self.num_processors = int(self.config.num_processors)
+        self.num_processors = self.config.num_processors
 
     def read_corrections(self):
         """Read the spectral corrections."""

--- a/py/picca/delta_extraction/survey.py
+++ b/py/picca/delta_extraction/survey.py
@@ -244,7 +244,7 @@ class Survey:
         self.logger.info(f"Reading masks. There are {num_masks} masks")
 
         for MaskType, mask_arguments in self.config.masks:
-            mask = MaskType(mask_arguments, self.config.keep_masked_pixels)
+            mask = MaskType(mask_arguments)
             self.masks.append(mask)
 
         t1 = time.time()


### PR DESCRIPTION
These changes speed up BAL catalog reading, and applications of masks. Masks are applied to forests in parallel. Simple extension with a class function gave pickling errors, so I had to create a separate class to handle individual pieces. Another addition is `np.searchsorted`. Not sure how big a difference it makes, but it should be faster in theory.

Edit: This also addresses issue #909 