### PR TITLE
Optional stack delta correction

### DIFF
--- a/py/picca/delta_extraction/expected_fluxes/dr16_expected_flux.py
+++ b/py/picca/delta_extraction/expected_fluxes/dr16_expected_flux.py
@@ -966,11 +966,14 @@ class Dr16ExpectedFlux(ExpectedFlux):
             if forest.bad_continuum_reason is not None:
                 continue
             # get the variance functions and statistics
-            stack_delta = self.get_stack_delta(forest.log_lambda)
             eta = self.get_eta(forest.log_lambda)
 
-            mean_expected_flux = forest.continuum
+            # assignment operator (=) creates a reference, such that
+            # mean_expected_flux points to forest.continuum and
+            # forest.continuum gets modified within if statement
+            mean_expected_flux = np.copy(forest.continuum)
             if self.force_stack_delta_to_zero:
+                stack_delta = self.get_stack_delta(forest.log_lambda)
                 mean_expected_flux *= stack_delta
             weights = self.get_continuum_weights(forest, mean_expected_flux)
             # this is needed as the weights from get_continuum_weights are

--- a/py/picca/tests/delta_extraction/data/.config.ini
+++ b/py/picca/tests/delta_extraction/data/.config.ini
@@ -56,6 +56,7 @@ use ivar as weight = False
 out dir = /Users/iperezra/software/picca/py/picca/tests/delta_extraction/results/config_tests/
 num processors = 1
 min num qso in fit = 100
+force stack delta to zero = True
 
 [correction arguments 0]
 filename = /Users/iperezra/software/picca/py/picca/tests/delta_extraction/data/delta_attributes.fits.gz

--- a/tutorials/delta_extraction/picca_delta_extraction_configuration_tutorial.ipynb
+++ b/tutorials/delta_extraction/picca_delta_extraction_configuration_tutorial.ipynb
@@ -298,6 +298,7 @@
     "- `order`: Order of the polynomial for the continuum fit. **Type: int, Required: no, Default: 1**\n",
     "- `use constant weight`: If \"True\", set all the delta weights to one (implemented as eta = 0, sigma_lss = 1, fudge = 0) **Type: bool, Required: no, Default: False**\n",
     "- `use ivar as weight`: If \"True\", use ivar as weights (implemented as eta = 1, sigma_lss = fudge = 0) **Type: bool, Required: no, Default: False**\n",
+    "- `force stack delta to zero`: If \"True\" (Default), continuum is corrected by stack_delta. **Type: bool, Required: no, Default: True**\n",
     "\n",
     "### TrueContinuum\n",
     "- `input directory`: Directory to spectra files. **Type: str, Required: yes**\n",


### PR DESCRIPTION
These changes add an option for `Dr16ExpectedFlux` that controls stack delta normalization in continuum fitting. The option is named `force stack delta to zero` and its default value (`True`) preserves the current behavior of continuum fitting. This flexibility will enable us to decouple and test calibration and numerical artifacts.