### PR TITLE
forest continuum is multiplied by transmission_correction in true

### DIFF
--- a/py/picca/delta_extraction/expected_fluxes/true_continuum.py
+++ b/py/picca/delta_extraction/expected_fluxes/true_continuum.py
@@ -351,6 +351,7 @@ class TrueContinuum(ExpectedFlux):
 
             forest.continuum = true_continuum(10**forest.log_lambda)
             forest.continuum *= self.get_mean_flux(forest.log_lambda)
+            forest.continuum *= forest.transmission_correction
 
         hdul.close()
         return forests


### PR DESCRIPTION
forest continuum is multiplied by transmission_correction in true continuum. this correction is needed for DLA masking + true continuum analysis