### PR TITLE
Add delta rebinning and optional fix for true continuum mean deltas

### DIFF
--- a/bin/picca_cf.py
+++ b/bin/picca_cf.py
@@ -217,6 +217,13 @@ def main(cmdargs):
                               'following the given seed. Do not shuffle if '
                               'None'))
 
+    parser.add_argument('--rebin-factor',
+                        type=int,
+                        default=None,
+                        required=False,
+                        help='Rebin factor for deltas. If not None, deltas will '
+                             'be rebinned by that factor')
+
     args = parser.parse_args(cmdargs)
 
     if args.nproc is None:
@@ -257,7 +264,9 @@ def main(cmdargs):
                                                   cosmo,
                                                   max_num_spec=args.nspec,
                                                   no_project=args.no_project,
-                                                  from_image=args.from_image)
+                                                  from_image=args.from_image,
+                                                  nproc=args.nproc,
+                                                  rebin_factor=args.rebin_factor)
     del z_max
     cf.data = data
     cf.num_data = num_data
@@ -286,7 +295,9 @@ def main(cmdargs):
             cosmo,
             max_num_spec=args.nspec,
             no_project=args.no_project,
-            from_image=args.from_image)
+            from_image=args.from_image,
+            nproc=args.nproc,
+            rebin_factor=args.rebin_factor)
         del z_max2
         cf.data2 = data2
         cf.num_data2 = num_data2

--- a/bin/picca_dmat.py
+++ b/bin/picca_dmat.py
@@ -225,6 +225,14 @@ def main(cmdargs):
         help=('rp can be positive or negative depending on the relative '
               'position between absorber1 and absorber2'))
 
+    parser.add_argument('--rebin-factor',
+                        type=int,
+                        default=None,
+                        required=False,
+                        help='Rebin factor for deltas. If not None, deltas will '
+                             'be rebinned by that factor')
+
+
     args = parser.parse_args(cmdargs)
 
     if args.nproc is None:
@@ -270,7 +278,9 @@ def main(cmdargs):
                                                   cf.z_ref,
                                                   cosmo,
                                                   max_num_spec=args.nspec,
-                                                  no_project=args.no_project)
+                                                  no_project=args.no_project,
+                                                  nproc=args.nproc,
+                                                  rebin_factor=args.rebin_factor)
     del z_max
     cf.data = data
     cf.num_data = num_data
@@ -298,7 +308,9 @@ def main(cmdargs):
             cf.z_ref,
             cosmo,
             max_num_spec=args.nspec,
-            no_project=args.no_project)
+            no_project=args.no_project,
+            nproc=args.nproc,
+            rebin_factor=args.rebin_factor)
         del z_max2
         cf.data2 = data2
         cf.num_data2 = num_data2

--- a/bin/picca_metal_dmat.py
+++ b/bin/picca_metal_dmat.py
@@ -256,6 +256,13 @@ def main(cmdargs):
         help=('rp can be positive or negative depending on the relative '
               'position between absorber1 and absorber2'))
 
+    parser.add_argument('--rebin-factor',
+                        type=int,
+                        default=None,
+                        required=False,
+                        help='Rebin factor for deltas. If not None, deltas will '
+                             'be rebinned by that factor')
+
     args = parser.parse_args(cmdargs)
 
     if args.nproc is None:
@@ -304,7 +311,9 @@ def main(cmdargs):
                                                   cf.alpha,
                                                   cf.z_ref,
                                                   cf.cosmo,
-                                                  max_num_spec=args.nspec)
+                                                  max_num_spec=args.nspec,
+                                                  nproc=args.nproc,
+                                                  rebin_factor=args.rebin_factor)
     del z_max
     cf.data = data
     cf.num_data = num_data
@@ -334,7 +343,9 @@ def main(cmdargs):
             cf.alpha2,
             cf.z_ref,
             cf.cosmo,
-            max_num_spec=args.nspec)
+            max_num_spec=args.nspec,
+            nproc=args.nproc,
+            rebin_factor=args.rebin_factor)
         del z_max2
         cf.data2 = data2
         cf.num_data2 = num_data2

--- a/bin/picca_metal_xdmat.py
+++ b/bin/picca_metal_xdmat.py
@@ -245,6 +245,13 @@ def main(cmdargs):
                         required=False,
                         help='Maximum number of spectra to read')
 
+    parser.add_argument('--rebin-factor',
+                        type=int,
+                        default=None,
+                        required=False,
+                        help='Rebin factor for deltas. If not None, deltas will '
+                             'be rebinned by that factor')
+
     args = parser.parse_args(cmdargs)
 
 
@@ -291,7 +298,9 @@ def main(cmdargs):
                                                   args.z_evol_del,
                                                   args.z_ref,
                                                   cosmo,
-                                                  max_num_spec=args.nspec)
+                                                  max_num_spec=args.nspec,
+                                                  nproc=args.nproc,
+                                                  rebin_factor=args.rebin_factor)
 
     xcf.data = data
     xcf.num_data = num_data

--- a/bin/picca_wick.py
+++ b/bin/picca_wick.py
@@ -254,6 +254,13 @@ def main(cmdargs):
                         required=False,
                         help='Maximum number of spectra to read')
 
+    parser.add_argument('--rebin-factor',
+                        type=int,
+                        default=None,
+                        required=False,
+                        help='Rebin factor for deltas. If not None, deltas will '
+                             'be rebinned by that factor')
+
     args = parser.parse_args(cmdargs)
 
     if args.nproc is None:
@@ -298,7 +305,9 @@ def main(cmdargs):
                                                   cf.alpha,
                                                   cf.z_ref,
                                                   cosmo,
-                                                  max_num_spec=args.nspec)
+                                                  max_num_spec=args.nspec,
+                                                  nproc=args.nproc,
+                                                  rebin_factor=args.rebin_factor)
     for deltas in data.values():
         for delta in deltas:
             delta.fname = 'D1'
@@ -388,7 +397,9 @@ def main(cmdargs):
             cf.alpha2,
             cf.z_ref,
             cosmo,
-            max_num_spec=args.nspec)
+            max_num_spec=args.nspec,
+            nproc=args.nproc,
+            rebin_factor=args.rebin_factor)
         for deltas in data.values():
             for delta in deltas:
                 delta.fname = 'D2'

--- a/bin/picca_xcf.py
+++ b/bin/picca_xcf.py
@@ -237,6 +237,14 @@ def main(cmdargs):
         help=('Shuffle the distribution of forests on the sky following the '
               'given seed. Do not shuffle if None'))
 
+    parser.add_argument('--rebin-factor',
+                        type=int,
+                        default=None,
+                        required=False,
+                        help='Rebin factor for deltas. If not None, deltas will '
+                             'be rebinned by that factor')
+
+
     args = parser.parse_args(cmdargs)
     if args.nproc is None:
         args.nproc = cpu_count() // 2
@@ -291,7 +299,9 @@ def main(cmdargs):
                                                   cosmo=cosmo,
                                                   max_num_spec=args.nspec,
                                                   no_project=args.no_project,
-                                                  from_image=args.from_image)
+                                                  from_image=args.from_image,
+                                                  nproc=args.nproc,
+                                                  rebin_factor=args.rebin_factor)
     xcf.data = data
     xcf.num_data = num_data
     userprint("")

--- a/bin/picca_xdmat.py
+++ b/bin/picca_xdmat.py
@@ -219,6 +219,13 @@ def main(cmdargs):
                         required=False,
                         help='Maximum number of spectra to read')
 
+    parser.add_argument('--rebin-factor',
+                        type=int,
+                        default=None,
+                        required=False,
+                        help='Rebin factor for deltas. If not None, deltas will '
+                             'be rebinned by that factor')
+
     args = parser.parse_args(cmdargs)
     if args.nproc is None:
         args.nproc = cpu_count() // 2
@@ -260,7 +267,9 @@ def main(cmdargs):
                                                   args.z_evol_del,
                                                   args.z_ref,
                                                   cosmo=cosmo,
-                                                  max_num_spec=args.nspec)
+                                                  max_num_spec=args.nspec,
+                                                  nproc=args.nproc,
+                                                  rebin_factor=args.rebin_factor)
     xcf.data = data
     xcf.num_data = num_data
     userprint("\n")

--- a/bin/picca_xwick.py
+++ b/bin/picca_xwick.py
@@ -238,6 +238,13 @@ def main(cmdargs):
                         required=False,
                         help='Maximum number of spectra to read')
 
+    parser.add_argument('--rebin-factor',
+                        type=int,
+                        default=None,
+                        required=False,
+                        help='Rebin factor for deltas. If not None, deltas will '
+                             'be rebinned by that factor')    
+
     args = parser.parse_args(cmdargs)
     if args.nproc is None:
         args.nproc = cpu_count() // 2
@@ -279,7 +286,9 @@ def main(cmdargs):
                                                   args.z_evol_del,
                                                   args.z_ref,
                                                   cosmo=cosmo,
-                                                  max_num_spec=args.nspec)
+                                                  max_num_spec=args.nspec,
+                                                  nproc=args.nproc,
+                                                  rebin_factor=args.rebin_factor)
     for deltas in data.values():
         for delta in deltas:
             delta.fname = 'D1'

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -1268,7 +1268,7 @@ class Delta(QSO):
     def rebin(self, factor):
         wave = 10**np.array(self.log_lambda)
         dwave = wave[1] - wave[0]
-        if np.isclose(dwave, wave[-1] - wave[-2]):
+        if not np.isclose(dwave, wave[-1] - wave[-2]):
             raise ValueError('Delta rebinning only implemented for linear lambda bins')
 
         start = wave.min() - dwave / 2
@@ -1287,6 +1287,6 @@ class Delta(QSO):
 
         new_wave = (edges[1:] + edges[:-1]) / 2
 
-        self.log_lambda = np.log10(new_wave)
-        self.delta = binned_delta
-        self.weights = binned_weight
+        self.log_lambda = np.log10(new_wave[mask])
+        self.delta = binned_delta[mask]
+        self.weights = binned_weight[mask]

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -1266,6 +1266,12 @@ class Delta(QSO):
         self.delta -= mean_delta + res
 
     def rebin(self, factor):
+        """Rebin deltas by an integer factor
+
+        Args:
+            factor: int
+                Factor to rebin deltas (new_bin_size = factor * old_bin_size)
+        """
         wave = 10**np.array(self.log_lambda)
         dwave = wave[1] - wave[0]
         if not np.isclose(dwave, wave[-1] - wave[-2]):

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -1244,7 +1244,7 @@ class Delta(QSO):
         fitiing. See equations 5 and 6 of du Mas des Bourboux et al. 2020
         """
         # 2nd term in equation 6
-        sum_weights=np.sum(self.weights)
+        sum_weights = np.sum(self.weights)
         if sum_weights > 0.0:
             mean_delta = np.average(self.delta, weights=self.weights)
         else:
@@ -1264,3 +1264,29 @@ class Delta(QSO):
             res = self.delta
 
         self.delta -= mean_delta + res
+
+    def rebin(self, factor):
+        wave = 10**np.array(self.log_lambda)
+        dwave = wave[1] - wave[0]
+        if np.isclose(dwave, wave[-1] - wave[-2]):
+            raise ValueError('Delta rebinning only implemented for linear lambda bins')
+
+        start = wave.min() - dwave / 2
+        num_bins = np.ceil(((wave[-1] - wave[0]) / dwave + 1) / factor)
+
+        edges = np.arange(num_bins) * dwave * factor + start
+
+        new_indx = np.searchsorted(edges, wave)
+
+        binned_delta = np.bincount(new_indx, weights=self.delta*self.weights,
+                                   minlength=edges.size+1)[1:-1]
+        binned_weight = np.bincount(new_indx, weights=self.weights, minlength=edges.size+1)[1:-1]
+
+        mask = binned_weight != 0
+        binned_delta[mask] /= binned_weight[mask]
+
+        new_wave = (edges[1:] + edges[:-1]) / 2
+
+        self.log_lambda = np.log10(new_wave)
+        self.delta = binned_delta
+        self.weights = binned_weight

--- a/py/picca/delta_extraction/expected_fluxes/true_continuum.py
+++ b/py/picca/delta_extraction/expected_fluxes/true_continuum.py
@@ -17,7 +17,7 @@ from picca.delta_extraction.utils import (find_bins, update_accepted_options,
 
 accepted_options = update_accepted_options(accepted_options, [
     "input directory", "raw statistics file", "use constant weight",
-    "num bins variance"
+    "num bins variance", "force stack delta to zero"
 ])
 
 defaults = update_default_options(defaults, {

--- a/py/picca/delta_extraction/expected_fluxes/true_continuum.py
+++ b/py/picca/delta_extraction/expected_fluxes/true_continuum.py
@@ -232,7 +232,7 @@ class TrueContinuum(ExpectedFlux):
                 weights = 1. / self.compute_forest_variance(
                     forest, forest.continuum)
 
-            mean_expected_flux = forest.continuum
+            mean_expected_flux = np.copy(forest.continuum)
             if self.force_stack_delta_to_zero:
                 stack_delta = self.get_stack_delta(forest.log_lambda)
                 mean_expected_flux *= stack_delta

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1534,6 +1534,7 @@ def read_deltas(in_dir,
 
     # Rebin
     if rebin_factor is not None:
+        userprint(f"Rebinning deltas by a factor of {rebin_factor}\n")
         for delta in deltas:
             delta.rebin(rebin_factor)
 

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1447,7 +1447,8 @@ def read_deltas(in_dir,
                 max_num_spec=None,
                 no_project=False,
                 from_image=None,
-                nproc=None):
+                nproc=None,
+                rebin_factor=None):
     """Reads deltas and computes their redshifts.
 
     Fills the fields delta.z and multiplies the weights by
@@ -1530,6 +1531,11 @@ def read_deltas(in_dir,
         num_data = len(deltas)
 
     userprint("\n")
+
+    # Rebin
+    if rebin_factor is not None:
+        for delta in deltas:
+            delta.rebin(rebin_factor)
 
     # compute healpix numbers
     phi = [delta.ra for delta in deltas]

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1422,6 +1422,8 @@ def read_delta_file(filename, from_image=None, rebin_factor=None):
             Path to the file to read
         from_image: bool - default: False
             Whether to use the from_image method.
+        rebin_factor: int - default: None
+            Factor to rebin the lambda grid by. If None, no rebinning is done.
     Returns:
         deltas:
             A dictionary with the data. Keys are the healpix numbers of each
@@ -1483,6 +1485,10 @@ def read_deltas(in_dir,
         from_image: list or None - default: None
             If not None, read the deltas from image files. The list of
             filenname for the image files should be paassed in from_image
+        nproc: int - default: None
+            Number of cpus for parallelization. If None, uses all available.
+        rebin_factor: int - default: None
+            Factor to rebin the lambda grid by. If None, no rebinning is done.
 
     Returns:
         The following variables:


### PR DESCRIPTION
The main update is an option to rebin deltas before computing correlations / distortion matrices. Needed for noiseless analyses, and for reducing the impact of biased weights in noisy analyses.

The second update is adding the "force stack delta to zero" option to the true continuum analysis to fix the mean delta different from zero problem. However, unlike with continuum fitting, this is turned off by default here.