### PR TITLE
Fix deltas rebin

### DIFF
--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -958,6 +958,7 @@ class Delta(QSO):
             Neighbouring deltas/quasars
         fname: string or None
             String identifying Delta as part of a group
+        delta_log_lambda
 
     Methods:
         __init__: Initializes class instances.
@@ -1315,17 +1316,16 @@ class Delta(QSO):
 
         self.delta -= mean_delta + res
 
-    def rebin(self, factor):
+    def rebin(self, factor, dwave=0.8):
         """Rebin deltas by an integer factor
 
         Args:
             factor: int
                 Factor to rebin deltas (new_bin_size = factor * old_bin_size)
+            dwave: float
+                Delta lambda of original deltas
         """
         wave = 10**np.array(self.log_lambda)
-        dwave = wave[1] - wave[0]
-        if not np.isclose(dwave, wave[-1] - wave[-2]):
-            raise ValueError('Delta rebinning only implemented for linear lambda bins')
 
         start = wave.min() - dwave / 2
         num_bins = np.ceil(((wave[-1] - wave[0]) / dwave + 1) / factor)

--- a/py/picca/data.py
+++ b/py/picca/data.py
@@ -958,7 +958,6 @@ class Delta(QSO):
             Neighbouring deltas/quasars
         fname: string or None
             String identifying Delta as part of a group
-        delta_log_lambda
 
     Methods:
         __init__: Initializes class instances.

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1435,8 +1435,6 @@ def read_delta_file(filename, rebin_factor=None):
     else:
         deltas = [Delta.from_fitsio(hdu) for hdu in hdul[1:]]
     
-    hdul.close()
-
     # Rebin
     if rebin_factor is not None:
         if 'LAMBDA' in hdul:
@@ -1452,6 +1450,8 @@ def read_delta_file(filename, rebin_factor=None):
             
         for i in range(len(deltas)):
             deltas[i].rebin(rebin_factor, dwave=dwave)
+            
+    hdul.close()
 
     return deltas
 

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -1524,12 +1524,9 @@ def read_deltas(in_dir,
         userprint(f"Rebinning deltas by a factor of {rebin_factor}\n")
 
     arguments = [(f, rebin_factor) for f in files]
-    results = []
-    for argument in arguments:
-        results.append(read_delta_file(*argument))
-    # pool = Pool(processes=nproc)
-    # results = pool.starmap(read_delta_file, arguments)
-    # pool.close()
+    pool = Pool(processes=nproc)
+    results = pool.starmap(read_delta_file, arguments)
+    pool.close()
 
     deltas = []
     num_data = 0


### PR DESCRIPTION
Previous implementation would fail if one of the first two pixels in the deltas field is masked.

Now, dwave (width of deltas) is read from the header of the deltas file, avoiding this problem. 

It works with both ImageHDU and TableHDU formats, but only for linear deltas (as before).