### PR TITLE
Pk1d zchunks

### DIFF
--- a/bin/picca_Pk1D_postprocess.py
+++ b/bin/picca_Pk1D_postprocess.py
@@ -117,14 +117,16 @@ def main(cmdargs):
     parser.add_argument('--weight-method',
                         type=str,
                         default='no_weights',
-                        help='Weighting scheme for the mean P1D computation,'
+                        help='SNR weighting scheme for the mean P1D computation,'
                              'Possible options: no_weights, simple_snr, fit_snr')
 
     parser.add_argument('--apply_z_weights',
                         action='store_true',
                         default=False,
                         required=False,
-                        help='[TMP] QMLE-like z weighting')
+                        help='If set, apply a z weighting scheme analog to that used for QMLE (eg. 2008.06421). '
+                             'Each chunk with mean redshift z contributes two nearest bins z_i (resp. z_j=z_i+dz), '
+                             'with weights |z-z_j|/dz (resp. |z-z_i|/dz).')
 
     parser.add_argument('--output-snrfit',
                         type=str,

--- a/bin/picca_Pk1D_postprocess.py
+++ b/bin/picca_Pk1D_postprocess.py
@@ -120,6 +120,12 @@ def main(cmdargs):
                         help='Weighting scheme for the mean P1D computation,'
                              'Possible options: no_weights, simple_snr, fit_snr')
 
+    parser.add_argument('--apply_z_weights',
+                        action='store_true',
+                        default=False,
+                        required=False,
+                        help='[TMP] QMLE-like z weighting')
+
     parser.add_argument('--output-snrfit',
                         type=str,
                         default=None,
@@ -206,6 +212,7 @@ def main(cmdargs):
                                     z_edges,
                                     k_edges,
                                     weight_method=args.weight_method,
+                                    apply_z_weights=args.apply_z_weights,
                                     output_snrfit=args.output_snrfit,
                                     snrcut=snrcut,
                                     zbins_snrcut=zbins_snrcut,

--- a/py/picca/pk1d/postproc_pk1d.py
+++ b/py/picca/pk1d/postproc_pk1d.py
@@ -244,13 +244,13 @@ def compute_mean_pk1d(p1d_table,
             if apply_z_weights:  # special chunk selection in that case
                 delta_z = zbin_centers[1:]-zbin_centers[:-1]
                 if not np.allclose(delta_z, delta_z[0], atol=1.e-3):
-                    raise ValueError("Option apply_z_weights is set: redshift bins should all have equal widths.")
+                    raise ValueError("z bins should have equal widths with apply_z_weights.")
                 delta_z = delta_z[0]
 
                 select = (p1d_table['k'] < kbin_edges[ikbin + 1]) & (
                             p1d_table['k'] > kbin_edges[ikbin]
                         )
-                if (izbin==0) or (izbin==nbins_z-1):
+                if izbin in (0, nbins_z-1):
                     # First and last bin: in order to avoid edge effects,
                     #    use only chunks within the bin
                     select = select & (
@@ -261,7 +261,8 @@ def compute_mean_pk1d(p1d_table,
                         p1d_table['forest_z'] < zbin_centers[izbin+1]) & (
                         p1d_table['forest_z'] > zbin_centers[izbin-1])
 
-                redshift_weights = 1.0 - np.abs(p1d_table['forest_z'][select]-zbin_centers[izbin])/delta_z
+                redshift_weights = 1.0 - np.abs(p1d_table['forest_z'][select]-
+                                                zbin_centers[izbin]) / delta_z
 
             else:
                 select = (p1d_table['forest_z'] < zbin_edges[izbin + 1]) & (

--- a/py/picca/pk1d/postproc_pk1d.py
+++ b/py/picca/pk1d/postproc_pk1d.py
@@ -379,12 +379,15 @@ def compute_mean_pk1d(p1d_table,
                     error = np.sqrt(alpha / (np.sum(weights) * (num_chunks - 1)))
 
                 elif weight_method == 'no_weights':
-                    mean = np.mean(p1d_table[col][select])
-                    # unbiased estimate: num_chunks-1
-                    error = np.std(p1d_table[col][select]) / np.sqrt(num_chunks - 1)
                     if apply_z_weights:
                         mean = np.average(p1d_table[col][select], weights=redshift_weights)
-                        # Note, we dont change the formula for the error as of now.
+                        # simple analytic expression:
+                        error = np.std(p1d_table[col][select]) * (
+                                np.sqrt(np.sum(redshift_weights**2)) / np.sum(redshift_weights) )
+                    else:
+                        mean = np.mean(p1d_table[col][select])
+                        # unbiased estimate: num_chunks-1
+                        error = np.std(p1d_table[col][select]) / np.sqrt(num_chunks - 1)
 
                 else:
                     raise ValueError(

--- a/py/picca/pk1d/postproc_pk1d.py
+++ b/py/picca/pk1d/postproc_pk1d.py
@@ -430,8 +430,7 @@ def run_postproc_pk1d(data_dir,
                                                       zbin_edges, kbin_edges,
                                                       weight_method, nomedians,
                                                       velunits, output_snrfit)
-    mean_p1d_table.meta['velunits'] = velunits
     result = fitsio.FITS(output_file, 'rw', clobber=True)
-    result.write(mean_p1d_table.as_array())
+    result.write(mean_p1d_table.as_array(), header={'velunits': velunits})
     result.write(metadata_table.as_array())
     result.close()

--- a/py/picca/pk1d/postproc_pk1d.py
+++ b/py/picca/pk1d/postproc_pk1d.py
@@ -348,7 +348,7 @@ def compute_mean_pk1d(p1d_table,
                         weights *= redshift_weights
                     mean = np.average(data_values, weights=weights)
                     if apply_z_weights:   # Analytic expression for the re-weighted average:
-                        error = np.sum(weights*redshift_weights)/(np.sum(weights))**2
+                        error = np.sqrt(np.sum(weights*redshift_weights))/np.sum(weights)
                     else:
                         error = np.sqrt(1. / np.sum(weights))
                     if output_snrfit is not None and col == 'Pk':


### PR DESCRIPTION
New option in pk1d_postprocess: --apply_z_weights (default False).
If set, each FFT chunck at redshift z contributes 2 nearby z bins, with a triangle-shape weight function identical to that used by the QMLE.
Tests with the fujilupe mocks show the impact on the measured P1D is less than 1%.
- The zmin and zmax redshift bins must necessarily be handled differently
- This PR also includes a minor bug fix (header in output P1D FITS file).