### PR TITLE
added H0 argument with default Planck2015 value for the cfs, dmats, metal matrices.

### DIFF
--- a/bin/picca_cf.py
+++ b/bin/picca_cf.py
@@ -165,7 +165,13 @@ def main(cmdargs):
                         required=False,
                         help=('Equation of state of dark energy of fiducial '
                               'LambdaCDM cosmology'))
-
+    
+    parser.add_argument('--fid-H0',
+                        type=float,
+                        default=67.31,
+                        required=False,
+                        help=('Hubble constant of fiducial LambdaCDM cosmology'))
+    
     parser.add_argument('--no-project',
                         action='store_true',
                         required=False,
@@ -244,6 +250,7 @@ def main(cmdargs):
                             Or=args.fid_Or,
                             Ok=args.fid_Ok,
                             wl=args.fid_wl,
+                            H0=arg.fid_H0,
                             blinding=blinding)
 
     t0 = time.time()

--- a/bin/picca_cf.py
+++ b/bin/picca_cf.py
@@ -165,13 +165,13 @@ def main(cmdargs):
                         required=False,
                         help=('Equation of state of dark energy of fiducial '
                               'LambdaCDM cosmology'))
-    
+
     parser.add_argument('--fid-H0',
                         type=float,
                         default=67.31,
                         required=False,
                         help=('Hubble constant of fiducial LambdaCDM cosmology'))
-    
+
     parser.add_argument('--no-project',
                         action='store_true',
                         required=False,
@@ -250,7 +250,7 @@ def main(cmdargs):
                             Or=args.fid_Or,
                             Ok=args.fid_Ok,
                             wl=args.fid_wl,
-                            H0=arg.fid_H0,
+                            H0=args.fid_H0,
                             blinding=blinding)
 
     t0 = time.time()

--- a/bin/picca_co.py
+++ b/bin/picca_co.py
@@ -169,6 +169,12 @@ def main(cmdargs):
         required=False,
         help='Equation of state of dark energy of fiducial LambdaCDM cosmology')
 
+    parser.add_argument('--fid-H0',
+                        type=float,
+                        default=67.31,
+                        required=False,
+                        help=('Hubble constant of fiducial LambdaCDM cosmology'))
+
     parser.add_argument(
         '--type-corr',
         type=str,
@@ -218,7 +224,8 @@ def main(cmdargs):
     cosmo = constants.Cosmo(Om=args.fid_Om,
                             Or=args.fid_Or,
                             Ok=args.fid_Ok,
-                            wl=args.fid_wl)
+                            wl=args.fid_wl,
+                            H0=args.fid_H0)
 
     ### Read objects 1
     objs, z_min = io.read_objects(args.drq, args.nside, args.z_min_obj,

--- a/bin/picca_dmat.py
+++ b/bin/picca_dmat.py
@@ -173,6 +173,12 @@ def main(cmdargs):
                         default=0.,
                         required=False,
                         help='Omega_k(z=0) of fiducial LambdaCDM cosmology')
+    
+    parser.add_argument('--fid-H0',
+                        type=float,
+                        default=67.31,
+                        required=False,
+                        help=('Hubble constant of fiducial LambdaCDM cosmology'))
 
     parser.add_argument(
         '--fid-wl',
@@ -266,6 +272,7 @@ def main(cmdargs):
                             Or=args.fid_Or,
                             Ok=args.fid_Ok,
                             wl=args.fid_wl,
+                            H0=arg.fid_H0,
                             blinding=blinding)
 
     t0 = time.time()

--- a/bin/picca_dmat.py
+++ b/bin/picca_dmat.py
@@ -173,7 +173,7 @@ def main(cmdargs):
                         default=0.,
                         required=False,
                         help='Omega_k(z=0) of fiducial LambdaCDM cosmology')
-    
+
     parser.add_argument('--fid-H0',
                         type=float,
                         default=67.31,
@@ -272,7 +272,7 @@ def main(cmdargs):
                             Or=args.fid_Or,
                             Ok=args.fid_Ok,
                             wl=args.fid_wl,
-                            H0=arg.fid_H0,
+                            H0=args.fid_H0,
                             blinding=blinding)
 
     t0 = time.time()

--- a/bin/picca_metal_dmat.py
+++ b/bin/picca_metal_dmat.py
@@ -216,7 +216,7 @@ def main(cmdargs):
         default=-1.,
         required=False,
         help='Equation of state of dark energy of fiducial LambdaCDM cosmology')
-    
+
     parser.add_argument('--fid-H0',
                         type=float,
                         default=67.31,
@@ -306,7 +306,7 @@ def main(cmdargs):
                                Or=args.fid_Or,
                                Ok=args.fid_Ok,
                                wl=args.fid_wl,
-                               H0=arg.fid_H0,
+                               H0=args.fid_H0,
                                blinding=blinding)
 
     t0 = time.time()

--- a/bin/picca_metal_dmat.py
+++ b/bin/picca_metal_dmat.py
@@ -216,6 +216,12 @@ def main(cmdargs):
         default=-1.,
         required=False,
         help='Equation of state of dark energy of fiducial LambdaCDM cosmology')
+    
+    parser.add_argument('--fid-H0',
+                        type=float,
+                        default=67.31,
+                        required=False,
+                        help=('Hubble constant of fiducial LambdaCDM cosmology'))
 
     parser.add_argument(
         '--remove-same-half-plate-close-pairs',
@@ -300,6 +306,7 @@ def main(cmdargs):
                                Or=args.fid_Or,
                                Ok=args.fid_Ok,
                                wl=args.fid_wl,
+                               H0=arg.fid_H0,
                                blinding=blinding)
 
     t0 = time.time()

--- a/bin/picca_metal_xdmat.py
+++ b/bin/picca_metal_xdmat.py
@@ -211,7 +211,7 @@ def main(cmdargs):
                         default=0.,
                         required=False,
                         help='Omega_k(z=0) of fiducial LambdaCDM cosmology')
-    
+
     parser.add_argument('--fid-H0',
                         type=float,
                         default=67.31,
@@ -292,7 +292,7 @@ def main(cmdargs):
                             Or=args.fid_Or,
                             Ok=args.fid_Ok,
                             wl=args.fid_wl,
-                            H0=arg.fid_H0,
+                            H0=args.fid_H0,
                             blinding=blinding)
     xcf.cosmo = cosmo
 

--- a/bin/picca_metal_xdmat.py
+++ b/bin/picca_metal_xdmat.py
@@ -211,6 +211,12 @@ def main(cmdargs):
                         default=0.,
                         required=False,
                         help='Omega_k(z=0) of fiducial LambdaCDM cosmology')
+    
+    parser.add_argument('--fid-H0',
+                        type=float,
+                        default=67.31,
+                        required=False,
+                        help=('Hubble constant of fiducial LambdaCDM cosmology'))
 
     parser.add_argument(
         '--fid-wl',
@@ -286,6 +292,7 @@ def main(cmdargs):
                             Or=args.fid_Or,
                             Ok=args.fid_Ok,
                             wl=args.fid_wl,
+                            H0=arg.fid_H0,
                             blinding=blinding)
     xcf.cosmo = cosmo
 

--- a/bin/picca_wick.py
+++ b/bin/picca_wick.py
@@ -172,6 +172,12 @@ def main(cmdargs):
         required=False,
         help='Equation of state of dark energy of fiducial LambdaCDM cosmology')
 
+    parser.add_argument('--fid-H0',
+                        type=float,
+                        default=67.31,
+                        required=False,
+                        help=('Hubble constant of fiducial LambdaCDM cosmology'))
+
     parser.add_argument('--no-project',
                         action='store_true',
                         required=False,
@@ -296,6 +302,7 @@ def main(cmdargs):
                             Or=args.fid_Or,
                             Ok=args.fid_Ok,
                             wl=args.fid_wl,
+                            H0=args.fid_H0,
                             blinding=blinding)
 
     # read data 1

--- a/bin/picca_xcf.py
+++ b/bin/picca_xcf.py
@@ -178,7 +178,7 @@ def main(cmdargs):
                         default=0.,
                         required=False,
                         help='Omega_k(z=0) of fiducial LambdaCDM cosmology')
-    
+
     parser.add_argument('--fid-H0',
                         type=float,
                         default=67.31,
@@ -267,7 +267,7 @@ def main(cmdargs):
                             Or=args.fid_Or,
                             Ok=args.fid_Ok,
                             wl=args.fid_wl,
-                            H0=arg.fid_H0,
+                            H0=args.fid_H0,
                             blinding=blinding)
 
     t0 = time.time()

--- a/bin/picca_xcf.py
+++ b/bin/picca_xcf.py
@@ -178,6 +178,12 @@ def main(cmdargs):
                         default=0.,
                         required=False,
                         help='Omega_k(z=0) of fiducial LambdaCDM cosmology')
+    
+    parser.add_argument('--fid-H0',
+                        type=float,
+                        default=67.31,
+                        required=False,
+                        help=('Hubble constant of fiducial LambdaCDM cosmology'))
 
     parser.add_argument(
         '--fid-wl',
@@ -261,6 +267,7 @@ def main(cmdargs):
                             Or=args.fid_Or,
                             Ok=args.fid_Ok,
                             wl=args.fid_wl,
+                            H0=arg.fid_H0,
                             blinding=blinding)
 
     t0 = time.time()

--- a/bin/picca_xcf_angl.py
+++ b/bin/picca_xcf_angl.py
@@ -191,6 +191,12 @@ def main(cmdargs):
         required=False,
         help='Equation of state of dark energy of fiducial LambdaCDM cosmology')
 
+    parser.add_argument('--fid-H0',
+                        type=float,
+                        default=67.31,
+                        required=False,
+                        help=('Hubble constant of fiducial LambdaCDM cosmology'))
+
     parser.add_argument('--no-project',
                         action='store_true',
                         required=False,
@@ -244,6 +250,7 @@ def main(cmdargs):
                             Or=args.fid_Or,
                             Ok=args.fid_Ok,
                             wl=args.fid_wl,
+                            H0=args.fid_H0,
                             blinding=blinding)
 
     ### Read deltas

--- a/bin/picca_xdmat.py
+++ b/bin/picca_xdmat.py
@@ -186,7 +186,7 @@ def main(cmdargs):
                         default=0.,
                         required=False,
                         help='Omega_k(z=0) of fiducial LambdaCDM cosmology')
-    
+
     parser.add_argument('--fid-H0',
                         type=float,
                         default=67.31,
@@ -262,7 +262,7 @@ def main(cmdargs):
                             Or=args.fid_Or,
                             Ok=args.fid_Ok,
                             wl=args.fid_wl,
-                            H0=arg.fid_H0,
+                            H0=args.fid_H0,
                             blinding=blinding)
 
     t0 = time.time()

--- a/bin/picca_xdmat.py
+++ b/bin/picca_xdmat.py
@@ -186,6 +186,12 @@ def main(cmdargs):
                         default=0.,
                         required=False,
                         help='Omega_k(z=0) of fiducial LambdaCDM cosmology')
+    
+    parser.add_argument('--fid-H0',
+                        type=float,
+                        default=67.31,
+                        required=False,
+                        help=('Hubble constant of fiducial LambdaCDM cosmology'))
 
     parser.add_argument(
         '--fid-wl',
@@ -256,6 +262,7 @@ def main(cmdargs):
                             Or=args.fid_Or,
                             Ok=args.fid_Ok,
                             wl=args.fid_wl,
+                            H0=arg.fid_H0,
                             blinding=blinding)
 
     t0 = time.time()

--- a/bin/picca_xwick.py
+++ b/bin/picca_xwick.py
@@ -184,6 +184,12 @@ def main(cmdargs):
         required=False,
         help='Equation of state of dark energy of fiducial LambdaCDM cosmology')
 
+    parser.add_argument('--fid-H0',
+                        type=float,
+                        default=67.31,
+                        required=False,
+                        help=('Hubble constant of fiducial LambdaCDM cosmology'))
+
     parser.add_argument('--max-diagram',
                         type=int,
                         default=4,
@@ -236,7 +242,7 @@ def main(cmdargs):
                         default=None,
                         required=False,
                         help='Rebin factor for deltas. If not None, deltas will '
-                             'be rebinned by that factor')    
+                             'be rebinned by that factor')
 
     args = parser.parse_args(cmdargs)
     if args.nproc is None:
@@ -270,6 +276,7 @@ def main(cmdargs):
                             Or=args.fid_Or,
                             Ok=args.fid_Ok,
                             wl=args.fid_wl,
+                            H0=args.fid_H0,
                             blinding=blinding)
 
     ### Read deltas

--- a/py/picca/tests/test_3_cor.py
+++ b/py/picca/tests/test_3_cor.py
@@ -145,6 +145,7 @@ class TestCor(AbstractTest):
         cmd += " --nt 15"
         cmd += " --nproc 1"
         cmd += ' --remove-same-half-plate-close-pairs'
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_cf.main(cmd.split()[1:])
 
@@ -173,6 +174,7 @@ class TestCor(AbstractTest):
         cmd += " --np 15"
         cmd += " --nt 15"
         cmd += " --nproc 1"
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_cf.main(cmd.split()[1:])
 
@@ -203,6 +205,7 @@ class TestCor(AbstractTest):
         cmd += " --rej 0.99"
         cmd += " --nproc 1"
         cmd += ' --remove-same-half-plate-close-pairs'
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_dmat.main(cmd.split()[1:])
 
@@ -234,6 +237,7 @@ class TestCor(AbstractTest):
         cmd += " --rej 0.99"
         cmd += " --nproc 1"
         cmd += ' --remove-same-half-plate-close-pairs'
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_metal_dmat.main(cmd.split()[1:])
 
@@ -264,6 +268,7 @@ class TestCor(AbstractTest):
         cmd += " --nt 15"
         cmd += " --rej 0.99"
         cmd += " --nproc 1"
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_wick.main(cmd.split()[1:])
 
@@ -310,6 +315,7 @@ class TestCor(AbstractTest):
         cmd += " --nproc 1"
         cmd += ' --remove-same-half-plate-close-pairs'
         cmd += " --unfold-cf"
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_cf.main(cmd.split()[1:])
 
@@ -343,6 +349,7 @@ class TestCor(AbstractTest):
         cmd += " --nproc 1"
         cmd += ' --remove-same-half-plate-close-pairs'
         cmd += " --unfold-cf"
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_dmat.main(cmd.split()[1:])
 
@@ -378,6 +385,7 @@ class TestCor(AbstractTest):
         cmd += " --nproc 1"
         cmd += ' --remove-same-half-plate-close-pairs'
         cmd += " --unfold-cf"
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_metal_dmat.main(cmd.split()[1:])
 
@@ -418,6 +426,7 @@ class TestCor(AbstractTest):
         cmd += " --drq " + self._masterFiles + "/test_delta/cat.fits"
         cmd += " --out " + self._branchFiles + "/Products/Correlations/xcf_angl.fits.gz"
         cmd += " --nproc 1"
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_xcf_angl.main(cmd.split()[1:])
 
@@ -446,6 +455,7 @@ class TestCor(AbstractTest):
         cmd += " --np 30"
         cmd += " --nt 15"
         cmd += " --nproc 1"
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_xcf.main(cmd.split()[1:])
 
@@ -477,6 +487,7 @@ class TestCor(AbstractTest):
         cmd += " --nt 15"
         cmd += " --rej 0.99"
         cmd += " --nproc 1"
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_xdmat.main(cmd.split()[1:])
 
@@ -506,6 +517,7 @@ class TestCor(AbstractTest):
         cmd += " --nt 15"
         cmd += " --rej 0.99"
         cmd += " --nproc 1"
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_metal_xdmat.main(cmd.split()[1:])
 
@@ -536,6 +548,7 @@ class TestCor(AbstractTest):
         cmd += " --nt 15"
         cmd += " --rej 0.99"
         cmd += " --nproc 1"
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_xwick.main(cmd.split()[1:])
 
@@ -600,6 +613,7 @@ class TestCor(AbstractTest):
         cmd += " --nt 15"
         cmd += " --nproc 1"
         cmd += " --type-corr DD"
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_co.main(cmd.split()[1:])
         ### Send
@@ -614,6 +628,7 @@ class TestCor(AbstractTest):
         cmd += " --nt 15"
         cmd += " --nproc 1"
         cmd += " --type-corr RR"
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_co.main(cmd.split()[1:])
         ### Send
@@ -629,6 +644,7 @@ class TestCor(AbstractTest):
         cmd += " --nt 15"
         cmd += " --nproc 1"
         cmd += " --type-corr DR"
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_co.main(cmd.split()[1:])
         ### Send
@@ -644,6 +660,7 @@ class TestCor(AbstractTest):
         cmd += " --nt 15"
         cmd += " --nproc 1"
         cmd += " --type-corr RD"
+        cmd += " --fid-H0 100"
         print(repr(cmd))
         picca.bin.picca_co.main(cmd.split()[1:])
 


### PR DESCRIPTION
I've added an H0 arg in picca_cf, picca_xcf, picca_dmat, picca_xdmat, picca_metal_dmat and picca_metal_xdmat and set the default value to Planck2015. Previously we were not passing this as an argument and it was stored in picca.constants.Cosmo as H0=100.