### PR TITLE
Change default redshift evolution to match QSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,12 @@ Before submitting a PR please make sure to:
 2. Update the data model
 3. For every file you have modified run
    ```
-   yapf --style google file.py -i 
+   yapf --style google file.py -i
    ```
    to ensure the coding styles are maintained.
 4. Consider using pylint to help in the debug process. From the repo folder run
    ```
-   pylint py/picca/delta_extraction/**/*py
+   pylint py/picca/delta_extraction/
+   pylint py/picca/pk1d/
    ```
+   depending on the module you are working on.

--- a/bin/picca_metal_xdmat.py
+++ b/bin/picca_metal_xdmat.py
@@ -181,7 +181,7 @@ def main(cmdargs):
     parser.add_argument(
         '--z-evol-obj',
         type=float,
-        default=1.,
+        default=1.44,
         required=False,
         help='Exponent of the redshift evolution of the object field')
 

--- a/bin/picca_xcf.py
+++ b/bin/picca_xcf.py
@@ -155,7 +155,7 @@ def main(cmdargs):
     parser.add_argument(
         '--z-evol-obj',
         type=float,
-        default=1.,
+        default=1.44,
         required=False,
         help='Exponent of the redshift evolution of the object field')
 

--- a/bin/picca_xcf1d.py
+++ b/bin/picca_xcf1d.py
@@ -142,7 +142,7 @@ def main(cmdargs):
     parser.add_argument(
         '--z-evol-obj',
         type=float,
-        default=1.,
+        default=1.44,
         required=False,
         help='Exponent of the redshift evolution of the object field')
 

--- a/bin/picca_xcf_angl.py
+++ b/bin/picca_xcf_angl.py
@@ -160,7 +160,7 @@ def main(cmdargs):
     parser.add_argument(
         '--z-evol-obj',
         type=float,
-        default=1.,
+        default=1.44,
         required=False,
         help='Exponent of the redshift evolution of the object field')
 

--- a/bin/picca_xdmat.py
+++ b/bin/picca_xdmat.py
@@ -163,7 +163,7 @@ def main(cmdargs):
     parser.add_argument(
         '--z-evol-obj',
         type=float,
-        default=1.,
+        default=1.44,
         required=False,
         help='Exponent of the redshift evolution of the object field')
 

--- a/bin/picca_xwick.py
+++ b/bin/picca_xwick.py
@@ -153,7 +153,7 @@ def main(cmdargs):
     parser.add_argument(
         '--z-evol-obj',
         type=float,
-        default=1.,
+        default=1.44,
         required=False,
         help='Exponent of the redshift evolution of the object field')
 

--- a/py/picca/tests/test_3_cor.py
+++ b/py/picca/tests/test_3_cor.py
@@ -34,6 +34,7 @@ import picca.bin.picca_export_co
 from picca.tests.test_helpers import AbstractTest
 
 
+# TODO: add test for xcf1d
 class TestCor(AbstractTest):
     """
         Tests the Correlation Function Computations
@@ -418,6 +419,7 @@ class TestCor(AbstractTest):
         cmd += " --drq " + self._masterFiles + "/test_delta/cat.fits"
         cmd += " --out " + self._branchFiles + "/Products/Correlations/xcf_angl.fits.gz"
         cmd += " --nproc 1"
+        cmd += " --z-evol-obj 1."
         print(repr(cmd))
         picca.bin.picca_xcf_angl.main(cmd.split()[1:])
 
@@ -446,6 +448,7 @@ class TestCor(AbstractTest):
         cmd += " --np 30"
         cmd += " --nt 15"
         cmd += " --nproc 1"
+        cmd += " --z-evol-obj 1."
         print(repr(cmd))
         picca.bin.picca_xcf.main(cmd.split()[1:])
 
@@ -477,6 +480,7 @@ class TestCor(AbstractTest):
         cmd += " --nt 15"
         cmd += " --rej 0.99"
         cmd += " --nproc 1"
+        cmd += " --z-evol-obj 1."
         print(repr(cmd))
         picca.bin.picca_xdmat.main(cmd.split()[1:])
 
@@ -506,6 +510,7 @@ class TestCor(AbstractTest):
         cmd += " --nt 15"
         cmd += " --rej 0.99"
         cmd += " --nproc 1"
+        cmd += " --z-evol-obj 1."
         print(repr(cmd))
         picca.bin.picca_metal_xdmat.main(cmd.split()[1:])
 
@@ -536,6 +541,7 @@ class TestCor(AbstractTest):
         cmd += " --nt 15"
         cmd += " --rej 0.99"
         cmd += " --nproc 1"
+        cmd += " --z-evol-obj 1."
         print(repr(cmd))
         picca.bin.picca_xwick.main(cmd.split()[1:])
 


### PR DESCRIPTION
When computing the cross-correlation (and xdmat, metal_xdmat, xwick, etc.) the redshift evolution parameter for discrete objects was set to 1. This PR changes it to 1.44 to match the value used for quasars in DR16. This is in line with what we do for the delta field where the default is 2.9 (value of alpha_lya).