### PR TITLE
Read lowercase calib fits

### DIFF
--- a/py/picca/delta_extraction/corrections/calibration_correction.py
+++ b/py/picca/delta_extraction/corrections/calibration_correction.py
@@ -47,11 +47,11 @@ class CalibrationCorrection(Correction):
                 "Missing argument 'filename' required by SdssCalibrationCorrection"
             )
         try:
-            hdu = fitsio.read(filename, ext="STACK_DELTAS")
-            if "LOGLAM" in hdu.dtype.names:
+            hdu = fitsio.FITS(filename)["STACK_DELTAS"]
+            if "LOGLAM" in [name.upper() for name in hdu.get_colnames()]:
                 stack_log_lambda = hdu['LOGLAM']
                 self.wave_solution = "log"
-            elif "LAMBDA" in hdu.dtype.names:
+            elif "LAMBDA" in [name.upper() for name in hdu.get_colnames()]:
                 stack_lambda = hdu['LAMBDA']
                 self.wave_solution = "lin"
             else:

--- a/py/picca/delta_extraction/corrections/calibration_correction.py
+++ b/py/picca/delta_extraction/corrections/calibration_correction.py
@@ -49,10 +49,10 @@ class CalibrationCorrection(Correction):
         try:
             hdu = fitsio.FITS(filename)["STACK_DELTAS"]
             if "LOGLAM" in [name.upper() for name in hdu.get_colnames()]:
-                stack_log_lambda = hdu['LOGLAM']
+                stack_log_lambda = hdu['LOGLAM'].read()
                 self.wave_solution = "log"
             elif "LAMBDA" in [name.upper() for name in hdu.get_colnames()]:
-                stack_lambda = hdu['LAMBDA']
+                stack_lambda = hdu['LAMBDA'].read()
                 self.wave_solution = "lin"
             else:
                 raise CorrectionError("Error loading CalibrationCorrection. In "
@@ -60,7 +60,7 @@ class CalibrationCorrection(Correction):
                                       f"{filename} one of the fields 'LOGLAM' "
                                       "or 'LAMBDA' should be present. I did not "
                                       "find them.")
-            stack_delta = hdu['STACK']
+            stack_delta = hdu['STACK'].read()
         except OSError as error:
             raise CorrectionError(
                 "Error loading CalibrationCorrection. "


### PR DESCRIPTION
If calibration was run using a previous picca version, and then we run the main run. There is an incompatibility between columnnames. Therefore it has to be read in case_insensitive mode. 

Although case_insensitive exists for function fitsio.read, it didn't work so I just used fitsio.FITS.