### PR TITLE
Fix raw io

### DIFF
--- a/py/picca/raw_io.py
+++ b/py/picca/raw_io.py
@@ -216,6 +216,7 @@ def write_delta_from_transmission(deltas, mean_flux, flux_variance, healpix, out
         header['MJD'] = delta.mjd
         header['FIBERID'] = delta.fiberid
         header['ORDER'] = delta.order
+        header['WAVE_SOLUTION'] = 'lin' if lin_spaced else 'log'
 
         cols = [
             delta.log_lambda, delta.delta, delta.weights,


### PR DESCRIPTION
Since the rebin option has been introduced in picca correlations, it's looking for the WAVE_SOLUTION field which already exists in delta extraction outputs. This adds that field to raw deltas as well.