### PR TITLE
SDSS fix

### DIFF
--- a/py/picca/delta_extraction/data_catalogues/sdss_data.py
+++ b/py/picca/delta_extraction/data_catalogues/sdss_data.py
@@ -139,10 +139,14 @@ class SdssData(Data):
                 continue
             self.logger.progress(f"Read {filename}")
 
-            log_lambda = np.array(hdul[1]["loglam"][:], dtype=np.float64)
-            flux = np.array(hdul[1]["flux"][:], dtype=np.float64)
-            ivar = (np.array(hdul[1]["ivar"][:], dtype=np.float64) *
-                    hdul[1]["and_mask"][:] == 0)
+            try:
+                log_lambda = np.array(hdul[1]["loglam"][:], dtype=np.float64)
+                flux = np.array(hdul[1]["flux"][:], dtype=np.float64)
+                ivar = (np.array(hdul[1]["ivar"][:], dtype=np.float64) *
+                        hdul[1]["and_mask"][:] == 0)
+            except:
+                self.logger.warning(f"Error with HDUs in {filename}. Ignoring file")
+                continue
 
             if self.analysis_type == "BAO 3D":
                 forest = SdssForest(

--- a/py/picca/delta_extraction/data_catalogues/sdss_data.py
+++ b/py/picca/delta_extraction/data_catalogues/sdss_data.py
@@ -144,8 +144,8 @@ class SdssData(Data):
                 flux = np.array(hdul[1]["flux"][:], dtype=np.float64)
                 ivar = (np.array(hdul[1]["ivar"][:], dtype=np.float64) *
                         hdul[1]["and_mask"][:] == 0)
-            except:
-                self.logger.warning(f"Error with HDUs in {filename}. Ignoring file")
+            except OSError:
+                self.logger.warning(f"Error reading HDU for {filename}. Ignoring file")
                 continue
 
             if self.analysis_type == "BAO 3D":


### PR DESCRIPTION
When reading SDSS spectra (using the DR16Q catalog), using mode="spec" ie. files spec-plate-mjd[..].fits, I found for at least one file an issue reading the file, the HDUs were not there (no idea why) so picca crashed.

This commit is a simple workaround.
