### PR TITLE
Update bump_version.yml

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 7.0.2
+current_version = 7.0.3
 commit = True
 
 [bumpversion:file:py/picca/_version.py]

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,25 +1,27 @@
 name: Bump version
 on: 
-  pull_request:
-  merge_group:
-        types: [checks_requested]
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'py/picca/_version.py'
+      - '.bumpversion.cfg'
 jobs:
   bump_version:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        github_token: ${{ secrets.PAT_MW_TOKEN_ACTION }}
     
     - name: Set up Python
       uses: actions/setup-python@v4
       
     - name: Install bump2version
       run:  pip install bump2version
-      
-    - name: Setup git
-      run: |
-        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
-      
+            
     - name: increase patch
       if: ${{ always() && (!contains(github.event.head_commit.message, '[bump major]')) && (!contains(github.event.head_commit.message, '[bump minor]')) && (!contains(github.event.head_commit.message, '[no bump]')) }}
       run: bump2version patch --verbose
@@ -37,7 +39,6 @@ jobs:
       run: echo "No version bump requested"
       
     - name: Push changes
-      if: ${{contains(github.ref_name, 'gh-readonly-queue') }}
       uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.PAT_MW_TOKEN_ACTION }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
     paths-ignore:
+      - '.github/**'
       - 'README.md'
       - 'CHANGELOG.md'
       - 'py/picca/_version.py'


### PR DESCRIPTION
This is one last try to fix the automated version bumping.
This is going back to what I originally put in, but using my personal access token instead of a github bot token. As I'm an admin (and the bot is not), I'm allowed to directly push the version change to master even with branch protection, which the bot is not.
As github has no way to automatically figure out infinite loops, this action cannot be allowed to run when only files affected by the version bumps change. So `.bumpversion.cfg` and `py/picca/_version.py` are on the exclusion list. I also added README and CHANGELOG for good manners so changes of those won't be version changes.