### PR TITLE
Fix xcf1d

### DIFF
--- a/bin/picca_xcf1d.py
+++ b/bin/picca_xcf1d.py
@@ -201,7 +201,7 @@ def main(cmdargs):
     xcf.z_cut_min = args.z_cut_min
     xcf.z_cut_max = args.z_cut_max
     xcf.num_bins_r_par = args.np
-    xcf.nt = 1
+    xcf.num_bins_r_trans = 1
     xcf.nside = args.nside
     xcf.ang_correlation = True
 

--- a/py/picca/xcf.py
+++ b/py/picca/xcf.py
@@ -881,20 +881,11 @@ def compute_xi_1d(healpixs):
             lambda_qso = [10.**obj.log_lambda for obj in neighbours]
             ang = np.zeros(len(lambda_qso))
 
-            (rebin_weight, rebin_xi, rebin_r_par, _, rebin_z,
-             rebin_num_pairs) = compute_xi_forest_pairs_fast(
+            compute_xi_forest_pairs_fast(
                  delta.z, 10.**delta.log_lambda, 10.**delta.log_lambda,
                  delta.weights, delta.delta, z_qso, lambda_qso, lambda_qso,
                  weights_qso, ang, weights1d, xi_1d, r_par1d, r_trans1d, z1d,
                  num_pairs1d)
-
-
-
-            xi_1d[:rebin_xi.size] += rebin_xi
-            weights1d[:rebin_weight.size] += rebin_weight
-            r_par1d[:rebin_r_par.size] += rebin_r_par
-            z1d[:rebin_z.size] += rebin_z
-            num_pairs1d[:rebin_num_pairs.size] += rebin_num_pairs.astype(int)
 
     w = weights1d > 0.
     xi_1d[w] /= weights1d[w]

--- a/py/picca/xcf.py
+++ b/py/picca/xcf.py
@@ -890,9 +890,9 @@ def compute_xi_1d(healpixs):
     w = weights1d > 0.
     xi_1d[w] /= weights1d[w]
     r_par1d[w] /= weights1d[w]
-    z[w] /= weights1d[w]
+    z1d[w] /= weights1d[w]
 
-    return weights1d, xi_1d, r_par1d, z, num_pairs1d
+    return weights1d, xi_1d, r_par1d, z1d, num_pairs1d
 
 
 @njit

--- a/py/picca/xcf.py
+++ b/py/picca/xcf.py
@@ -864,6 +864,9 @@ def compute_xi_1d(healpixs):
     z1d = np.zeros(num_bins_r_par)
     num_pairs1d = np.zeros(num_bins_r_par, dtype=np.int64)
 
+    # not used only defined so that we can run compute_xi_forest_pairs_fast
+    r_trans1d = np.zeros(num_bins_r_par)
+
     for healpix in healpixs:
         for delta in data[healpix]:
 
@@ -882,7 +885,10 @@ def compute_xi_1d(healpixs):
              rebin_num_pairs) = compute_xi_forest_pairs_fast(
                  delta.z, 10.**delta.log_lambda, 10.**delta.log_lambda,
                  delta.weights, delta.delta, z_qso, lambda_qso, lambda_qso,
-                 weights_qso, ang)
+                 weights_qso, ang, weights1d, xi_1d, r_par1d, r_trans1d, z1d,
+                 num_pairs1d)
+
+
 
             xi_1d[:rebin_xi.size] += rebin_xi
             weights1d[:rebin_weight.size] += rebin_weight


### PR DESCRIPTION
Fix longstanding issues in the xcf1d computation. The code is seldom used and that is why we did not notice it was broken (also it is not included in the tests)