### PR TITLE
Update the github action for tests

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 #    env:   
 #      OMP_NUM_THREADS: 1
 #      MKL_NUM_THREADS: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.20.3
 scipy>=1.6.3
-iminuit==2.6.1
+iminuit>=2.6.1
 healpy>=1.14.0
 fitsio>=1.1.4
 llvmlite>=0.36.0


### PR DESCRIPTION
This updates the test github action to use python 3.9 - 3.11 to make sure we actually test on recent versions