### PR TITLE
new option per_r_par for covariance smoothing

### DIFF
--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -69,6 +69,11 @@ def main(cmdargs):
         action='store_true',
         default=False,
         help='Do not smooth the covariance matrix')
+    parser.add_argument(
+        '--smooth-per-r-par',
+        action='store_true',
+        default=False,
+        help='Consider different correlation coefficients per r_par')
 
     parser.add_argument(
         '--blind-corr-type',
@@ -149,12 +154,15 @@ def main(cmdargs):
         delta_r_trans = (r_trans_max - 0.) / num_bins_r_trans
         if not args.do_not_smooth_cov:
             userprint("INFO: The covariance will be smoothed")
+            if args.smooth_per_r_par :
+                userprint("INFO: with different correlation coefficients per r_par")
             covariance = smooth_cov(xi,
                                     weights,
                                     r_par,
                                     r_trans,
                                     delta_r_trans=delta_r_trans,
-                                    delta_r_par=delta_r_par)
+                                    delta_r_par=delta_r_par,
+                                    per_r_par=args.smooth_per_r_par)
         else:
             userprint("INFO: The covariance will not be smoothed")
             covariance = compute_cov(xi, weights)

--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -110,7 +110,8 @@ def smooth_cov(xi,
     sum_correlation = {}
     counts_correlation = {}
     for index in range(num_bins):
-        index_r_par = int(r_par[index]/delta_r_par)
+        if per_r_par :
+            index_r_par = int(r_par[index]/delta_r_par)
         userprint("\rsmoothing {}".format(index), end="")
         for index2 in range(index + 1, num_bins):
             index_delta_r_par = round(
@@ -136,7 +137,8 @@ def smooth_cov(xi,
 
     for index in range(num_bins):
         correlation_smooth[index, index] = 1.
-        index_r_par = int(r_par[index]/delta_r_par)
+        if per_r_par :
+            index_r_par = int(r_par[index]/delta_r_par)
         for index2 in range(index + 1, num_bins):
             index_delta_r_par = round(
                 abs(r_par[index2] - r_par[index]) / delta_r_par)


### PR DESCRIPTION
- add option per_r_par to picca.utils.smooth_cov 
  if per_r_par=True (False by default), the correlation coefficients are averaged per (rpar,delta_rpar,delta_rperp) and not per (delta_rpar,delta_rperp).
- add option --smooth-per-r-par to picca_export.py

This is useful for some correlation functions where the default scheme is not accurate and can lead to non positive matrices.
For instance SIV and CIV side bands auto-correlations, or the lyb x lya cross-correlation.

Example:
```
# default (non positive output matrix)
picca_export.py --data /global/cfs/cdirs/desicollab/science/lya/y1-kp6/iron-tests/correlations/correlation-lyalyb-1-0-0/cf_lya_x_lyb.fits --out cf_lya_x_lyb_exp.fits --blind-corr-type lyaxlyb

# with new option (positive output matrix)
picca_export.py --data /global/cfs/cdirs/desicollab/science/lya/y1-kp6/iron-tests/correlations/correlation-lyalyb-1-0-0/cf_lya_x_lyb.fits --out cf_lya_x_lyb_exp_bis.fits --blind-corr-type lyaxlyb --smooth-per-r-par

```