### PR TITLE
added fast-metals option to picca_metal_dmat [minor]

### DIFF
--- a/bin/picca_metal_dmat.py
+++ b/bin/picca_metal_dmat.py
@@ -17,6 +17,8 @@ import fitsio
 from picca import constants, cf, utils, io
 from picca.utils import userprint
 
+#store the default silicon metals modelled in the CF/XCF
+DEFAULT_SI_METALS = ['SiIII(1207)','SiII(1190)','SiII(1193)','SiII(1260)']
 
 def calc_metal_dmat(abs_igm1, abs_igm2, healpixs):
     """Computes the metal distortion matrix.
@@ -313,9 +315,7 @@ def main(cmdargs):
     cf.alpha_abs[args.lambda_abs] = cf.alpha
     for metal in args.abs_igm:
         cf.alpha_abs[metal] = args.metal_alpha
-    
-    #store the default silicon metals modelled in the CF/XCF
-    DEFAULT_SI_METALS = ['SiIII(1207)','SiII(1190)','SiII(1193)','SiII(1260)']
+
 
     # read blinding keyword
     blinding = io.read_blinding(args.in_dir)
@@ -425,8 +425,8 @@ def main(cmdargs):
         for index2, abs_igm2 in enumerate(abs_igm_2[index0:]):
             if index1 == 0 and index2 == 0:
                 continue
-            
-            
+
+
             if not (abs_igm1 == "LYA" and abs_igm2 in DEFAULT_SI_METALS) \
             and not (abs_igm1 == "CIV(eff)" and abs_igm1 == abs_igm2):
                 continue

--- a/bin/picca_metal_dmat.py
+++ b/bin/picca_metal_dmat.py
@@ -316,7 +316,6 @@ def main(cmdargs):
     for metal in args.abs_igm:
         cf.alpha_abs[metal] = args.metal_alpha
 
-
     # read blinding keyword
     blinding = io.read_blinding(args.in_dir)
 
@@ -426,10 +425,10 @@ def main(cmdargs):
             if index1 == 0 and index2 == 0:
                 continue
 
-
-            if not (abs_igm1 == "LYA" and abs_igm2 in DEFAULT_SI_METALS) \
-            and not (abs_igm1 == "CIV(eff)" and abs_igm1 == abs_igm2):
-                continue
+            if args.fast_metals:
+                if not (abs_igm1 == "LYA" and abs_igm2 in DEFAULT_SI_METALS) \
+                and not (abs_igm1 == "CIV(eff)" and abs_igm1 == abs_igm2):
+                    continue
 
             cf.counter.value = 0
             calc_metal_dmat_wrapper = partial(calc_metal_dmat, abs_igm1,

--- a/bin/picca_metal_dmat.py
+++ b/bin/picca_metal_dmat.py
@@ -279,6 +279,12 @@ def main(cmdargs):
                         help='Rebin factor for deltas. If not None, deltas will '
                              'be rebinned by that factor')
 
+    parser.add_argument('--fast-metals',
+                    action='store_true',
+                    required=False,
+                    help='compute only the metal correlations used by Vega'
+                       'i.e. 4 LyaxSi matrices and CIVxCIV')
+
     args = parser.parse_args(cmdargs)
 
     if args.nproc is None:
@@ -416,6 +422,16 @@ def main(cmdargs):
         for index2, abs_igm2 in enumerate(abs_igm_2[index0:]):
             if index1 == 0 and index2 == 0:
                 continue
+
+            if args.fast_metals:
+                default_si_metals = ['SiIII(1207)','SiII(1190)','SiII(1193)','SiII(1260)']
+                if (abs_igm1=='LYA')&(abs_igm2 in default_si_metals):
+                    pass
+                elif abs_igm1==abs_igm2=='CIV(eff)':
+                    pass
+                else:
+                    continue
+
             cf.counter.value = 0
             calc_metal_dmat_wrapper = partial(calc_metal_dmat, abs_igm1,
                                               abs_igm2)

--- a/bin/picca_metal_dmat.py
+++ b/bin/picca_metal_dmat.py
@@ -313,6 +313,9 @@ def main(cmdargs):
     cf.alpha_abs[args.lambda_abs] = cf.alpha
     for metal in args.abs_igm:
         cf.alpha_abs[metal] = args.metal_alpha
+    
+    #store the default silicon metals modelled in the CF/XCF
+    DEFAULT_SI_METALS = ['SiIII(1207)','SiII(1190)','SiII(1193)','SiII(1260)']
 
     # read blinding keyword
     blinding = io.read_blinding(args.in_dir)
@@ -422,15 +425,11 @@ def main(cmdargs):
         for index2, abs_igm2 in enumerate(abs_igm_2[index0:]):
             if index1 == 0 and index2 == 0:
                 continue
-
-            if args.fast_metals:
-                default_si_metals = ['SiIII(1207)','SiII(1190)','SiII(1193)','SiII(1260)']
-                if (abs_igm1=='LYA')&(abs_igm2 in default_si_metals):
-                    pass
-                elif abs_igm1==abs_igm2=='CIV(eff)':
-                    pass
-                else:
-                    continue
+            
+            
+            if not (abs_igm1 == "LYA" and abs_igm2 in DEFAULT_SI_METALS) \
+            and not (abs_igm1 == "CIV(eff)" and abs_igm1 == abs_igm2):
+                continue
 
             cf.counter.value = 0
             calc_metal_dmat_wrapper = partial(calc_metal_dmat, abs_igm1,


### PR DESCRIPTION
Calling this option only computes the relevant 4 LYA x Si and CIVxCIV.