### PR TITLE
Update picca_delta_extraction_configuration_tutorial.ipynb

### DIFF
--- a/tutorials/delta_extraction/picca_delta_extraction_configuration_tutorial.ipynb
+++ b/tutorials/delta_extraction/picca_delta_extraction_configuration_tutorial.ipynb
@@ -505,8 +505,8 @@
     "- `num iterations`: Number of iterations to determine LSS variance. **Type: int, Required: no, Default: 5**\n",
     "- `raw statistics file`: File containing Large Scale Structure delta variance and mean transmitted flux. Should have the same format as files written by the raw analysis. If empty, the name is inferred based on the run settings (might not work for all settings) **Type: str, Required: no, Default: \"\"**\n",
     "- `use constant weight`: If \"True\", set all the delta weights to one (implemented as eta = 0, sigma_lss = 1, fudge = 0) **Type: bool, Required: no, Default: False**\n"
-    "- `use splines`: If \"True\", use VAR_SPLINE column for the flux variance and MEANFLUX_SPLINE for the mean flux. If \"False\", use VAR and MEANFLUX instead. Required: no, Default: True**\n"
-    "- `recompute var lss`: If \"True\", recalculates var_lss. Required: no, Default: False**\n"
+    "- `use splines`: If \"True\", use VAR_SPLINE column for the flux variance and MEANFLUX_SPLINE for the mean flux. If \"False\", use VAR and MEANFLUX instead. **Type: bool, Required: no, Default: True**\n"
+    "- `recompute var lss`: If \"True\", recalculates var_lss. **Type: bool, Required: no, Default: False**\n"
    ]
   },
   {

--- a/tutorials/delta_extraction/picca_delta_extraction_configuration_tutorial.ipynb
+++ b/tutorials/delta_extraction/picca_delta_extraction_configuration_tutorial.ipynb
@@ -505,6 +505,8 @@
     "- `num iterations`: Number of iterations to determine LSS variance. **Type: int, Required: no, Default: 5**\n",
     "- `raw statistics file`: File containing Large Scale Structure delta variance and mean transmitted flux. Should have the same format as files written by the raw analysis. If empty, the name is inferred based on the run settings (might not work for all settings) **Type: str, Required: no, Default: \"\"**\n",
     "- `use constant weight`: If \"True\", set all the delta weights to one (implemented as eta = 0, sigma_lss = 1, fudge = 0) **Type: bool, Required: no, Default: False**\n"
+    "- `use splines`: If \"True\", use VAR_SPLINE column for the flux variance and MEANFLUX_SPLINE for the mean flux. If \"False\", use VAR and MEANFLUX instead. Required: no, Default: True**\n"
+    "- `recompute var lss`: If \"True\", recalculates var_lss. Required: no, Default: False**\n"
    ]
   },
   {

--- a/tutorials/delta_extraction/picca_delta_extraction_configuration_tutorial.ipynb
+++ b/tutorials/delta_extraction/picca_delta_extraction_configuration_tutorial.ipynb
@@ -504,8 +504,8 @@
     "- `iter out prefix`: Prefix of the iteration files. These file contain the statistical properties of deltas at a given iteration step. Intermediate files will add '_iteration{num}.fits.gz' to the prefix for intermediate steps and '.fits.gz' for the final results. For now there is only one iteration available, but this might change in the future. The prefix should not contain any folders. **Type: str, Required: no**\n",
     "- `num iterations`: Number of iterations to determine LSS variance. **Type: int, Required: no, Default: 5**\n",
     "- `raw statistics file`: File containing Large Scale Structure delta variance and mean transmitted flux. Should have the same format as files written by the raw analysis. If empty, the name is inferred based on the run settings (might not work for all settings) **Type: str, Required: no, Default: \"\"**\n",
-    "- `use constant weight`: If \"True\", set all the delta weights to one (implemented as eta = 0, sigma_lss = 1, fudge = 0) **Type: bool, Required: no, Default: False**\n"
-    "- `use splines`: If \"True\", use VAR_SPLINE column for the flux variance and MEANFLUX_SPLINE for the mean flux. If \"False\", use VAR and MEANFLUX instead. **Type: bool, Required: no, Default: True**\n"
+    "- `use constant weight`: If \"True\", set all the delta weights to one (implemented as eta = 0, sigma_lss = 1, fudge = 0) **Type: bool, Required: no, Default: False**\n",
+    "- `use splines`: If \"True\", use VAR_SPLINE column for the flux variance and MEANFLUX_SPLINE for the mean flux. If \"False\", use VAR and MEANFLUX instead. **Type: bool, Required: no, Default: True**\n",
     "- `recompute var lss`: If \"True\", recalculates var_lss. **Type: bool, Required: no, Default: False**\n"
    ]
   },


### PR DESCRIPTION
use splines and recompute var lss options are missing in the tutorial. This PR adds description for those.