### PR TITLE
Redshifts in metal matrices [bump minor]

### DIFF
--- a/bin/picca_fast_metal_dmat.py
+++ b/bin/picca_fast_metal_dmat.py
@@ -135,11 +135,14 @@ def calc_fast_metal_dmat(in_lambda_abs_1,
                                         bins=rpbins,
                                         weights=weights *
                                         (output_rp[None, :].ravel()))
+
+    # return the redshift of the actual absorber, which is the average of input_z1
+    # and input_z2
     sum_out_weight_z, _ = np.histogram(
         output_rp,
         bins=rpbins,
         weights=weights *
-        (((output_z1[:, None] + output_z2[None, :]) / 2.).ravel()))
+        (((input_z1[:, None] + input_z2[None, :]) / 2.).ravel()))
     r_par_eff = sum_out_weight_rp / (sum_out_weight + (sum_out_weight == 0))
     z_eff = sum_out_weight_z / (sum_out_weight + (sum_out_weight == 0))
 

--- a/bin/picca_fast_metal_xdmat.py
+++ b/bin/picca_fast_metal_xdmat.py
@@ -122,11 +122,14 @@ def calc_fast_metal_dmat(in_lambda_abs,
                                         bins=rpbins,
                                         weights=weights *
                                         (output_rp[None, :].ravel()))
+
+    # return the redshift of the actual absorber, which is the average of input_zf
+    # and z_qso
     sum_out_weight_z, _ = np.histogram(
         output_rp,
         bins=rpbins,
         weights=weights *
-        (((output_zf[:, None] + z_qso[None, :]) / 2.).ravel()))
+        (((input_zf[:, None] + z_qso[None, :]) / 2.).ravel()))
     r_par_eff = sum_out_weight_rp / (sum_out_weight + (sum_out_weight == 0))
     z_eff = sum_out_weight_z / (sum_out_weight + (sum_out_weight == 0))
 


### PR DESCRIPTION
Record in the metal matrices the weighted mean redshift of the input to the remapping matrix (i.e. the true absorber redshift) and not the output of the remapping (the 'incorrect' Lya redshift). Both redshifts (input and output) could be useful, but for the purpose of interpreting correctly the metal biases coming from a fit using the metal matrices, the metal redshifts are obviously the correct ones to use. This is what was done in the previous code, so we are fixing here an inconsistency.

This PR addresses issue #1044 .