### PR TITLE
Fix raw mocks bug

### DIFF
--- a/py/picca/raw_io.py
+++ b/py/picca/raw_io.py
@@ -217,6 +217,7 @@ def write_delta_from_transmission(deltas, mean_flux, flux_variance, healpix, out
         header['FIBERID'] = delta.fiberid
         header['ORDER'] = delta.order
         header['WAVE_SOLUTION'] = 'lin' if lin_spaced else 'log'
+        header['DELTA_LAMBDA'] = delta_x
 
         cols = [
             delta.log_lambda, delta.delta, delta.weights,


### PR DESCRIPTION
We cannot run raw mock correlations with the rebin option due to missing delta_lambda field in the header of raw mock deltas.