### PR TITLE
Add flag to turn off non-blind cosmology messages

### DIFF
--- a/py/picca/constants.py
+++ b/py/picca/constants.py
@@ -160,7 +160,7 @@ class Cosmo(object):
         """
         raise NotImplementedError("Function should be specified at run-time")
 
-    def __init__(self,Om,Ok=0.,Or=0.,wl=-1.,blinding=False):
+    def __init__(self,Om,Ok=0.,Or=0.,wl=-1.,blinding=False,verbose=True):
         """Initializes the methods for this instance
 
         Args:
@@ -184,12 +184,14 @@ class Cosmo(object):
 
         # Blind data
         if blinding == "none":
-            userprint("ATTENTION: Analysis is not blinded!")
+            if verbose:
+                userprint("ATTENTION: Analysis is not blinded!")
         else:
             userprint(f"ATTENTION: Analysis is blinded with strategy {blinding}")
 
         if blinding not in  ["strategyB", "strategyBC"]:
-            userprint(f"Om={Om}, Or={Or}, wl={wl}")
+            if verbose:
+                userprint(f"Om={Om}, Or={Or}, wl={wl}")
         else:
             userprint("The specified cosmology is "
                       f"not used: Om={Om}, Or={Or}, wl={wl}")


### PR DESCRIPTION
Picca will briefly become a dependency of Vega (as I will discuss tomorrow), and we will be calling the Cosmo class from outside. Therefore we need a flag to turn off the print statements done when there is no blinding, because they are not relevant when this is called from Vega.