### PR TITLE
[bump major] Unblinding y1

### DIFF
--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -11,6 +11,7 @@ import os.path
 
 from picca.utils import smooth_cov, compute_cov
 from picca.utils import userprint
+from picca.delta_extraction.utils import UNBLINDABLE_STRATEGIES
 
 
 def main(cmdargs):
@@ -264,7 +265,7 @@ def main(cmdargs):
     ]
 
     # Check if we need to unblind
-    if blinding in ['desi_y1', 'desi_m2']:
+    if blinding in UNBLINDABLE_STRATEGIES:
         userprint("Y1 correlations are not blinded.")
         blinding = 'none'
         data_name = 'DA'

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -81,12 +81,6 @@ def main(cmdargs):
         choices=['lyaxlya', 'lyaxlyb', 'qsoxlya', 'qsoxlyb'],
         help='Type of correlation. Required to apply blinding in DESI')
 
-    parser.add_argument(
-        '--unblind-y1',
-        action='store_true',
-        default=False,
-        help='Unblind the Y1 correlations.')
-
     args = parser.parse_args(cmdargs)
 
     hdul = fitsio.FITS(args.data)
@@ -270,23 +264,16 @@ def main(cmdargs):
     ]
 
     # Check if we need to unblind
-    if args.unblind_y1:
-        if blinding == 'desi_y1':
-            userprint("Unblinding Y1 correlations.")
-            blinding = 'none'
-            data_name = 'DA'
-            dmat_name = 'DM'
-        else:
-            raise ValueError("Unblinding requires blinding to be 'desi_y1'. Found {}.".format(blinding))
+    if blinding in ['desi_y1', 'desi_m2']:
+        userprint("Y1 correlations are not blinded.")
+        blinding = 'none'
+        data_name = 'DA'
+        dmat_name = 'DM'
 
     # Check if we need blinding and apply it
     if 'BLIND' in data_name or blinding != 'none':
         blinding_dir = '/global/cfs/projectdirs/desi/science/lya/y1-kp6/blinding/'
-        blinding_templates = {'desi_m2': {'standard': 'm2_blinding_v1.2_standard_29_03_2022.h5',
-                                          'grid': 'm2_blinding_v1.2_regular_grid_29_03_2022.h5'},
-                              'desi_y1': {'standard': 'y1_blinding_v2_standard_17_12_2022.h5',
-                                          'grid': 'y1_blinding_v2_regular_grid_17_12_2022.h5'},
-                              'desi_y3': {'standard': 'y3_blinding_v3_standard_18_12_2022.h5',
+        blinding_templates = {'desi_y3': {'standard': 'y3_blinding_v3_standard_18_12_2022.h5',
                                           'grid': 'y3_blinding_v3_regular_grid_18_12_2022.h5'}}
 
         if blinding in blinding_templates:

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -266,7 +266,7 @@ def main(cmdargs):
 
     # Check if we need to unblind
     if blinding in UNBLINDABLE_STRATEGIES:
-        userprint("Y1 correlations are not blinded.")
+        userprint(f"'{blinding}' correlations are not blinded.")
         blinding = 'none'
         data_name = 'DA'
         dmat_name = 'DM'

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -81,6 +81,12 @@ def main(cmdargs):
         choices=['lyaxlya', 'lyaxlyb', 'qsoxlya', 'qsoxlyb'],
         help='Type of correlation. Required to apply blinding in DESI')
 
+    parser.add_argument(
+        '--unblind-y1',
+        action='store_true',
+        default=False,
+        help='Unblind the Y1 correlations.')
+
     args = parser.parse_args(cmdargs)
 
     hdul = fitsio.FITS(args.data)
@@ -220,8 +226,7 @@ def main(cmdargs):
         'name': "BLINDING",
         'value': blinding,
         'comment': 'String specifying the blinding strategy'
-    },
-    {
+    }, {
         'name': 'RPMIN',
         'value': r_par_min,
         'comment': 'Minimum r-parallel'
@@ -263,6 +268,16 @@ def main(cmdargs):
         'R-parallel', 'R-transverse', 'Redshift', 'Correlation',
         'Covariance matrix', 'Distortion matrix', 'Number of pairs'
     ]
+
+    # Check if we need to unblind
+    if args.unblind_y1:
+        if blinding == 'desi_y1':
+            userprint("Unblinding Y1 correlations.")
+            blinding = 'none'
+            data_name = 'DA'
+            dmat_name = 'DM'
+        else:
+            raise ValueError("Unblinding requires blinding to be 'desi_y1'. Found {}.".format(blinding))
 
     # Check if we need blinding and apply it
     if 'BLIND' in data_name or blinding != 'none':

--- a/bin/picca_export.py
+++ b/bin/picca_export.py
@@ -11,7 +11,9 @@ import os.path
 
 from picca.utils import smooth_cov, compute_cov
 from picca.utils import userprint
-from picca.delta_extraction.utils import UNBLINDABLE_STRATEGIES
+
+# TODO: add tags here when we are allowed to unblind them
+UNBLINDABLE_STRATEGIES = ["none", "desi_m2", "desi_y1"]
 
 
 def main(cmdargs):

--- a/py/picca/delta_extraction/data_catalogues/desi_data.py
+++ b/py/picca/delta_extraction/data_catalogues/desi_data.py
@@ -15,7 +15,7 @@ from picca.delta_extraction.quasar_catalogues.desi_quasar_catalogue import (
 from picca.delta_extraction.quasar_catalogues.desi_quasar_catalogue import (
     defaults as defaults_quasar_catalogue)
 from picca.delta_extraction.utils import (
-    ACCEPTED_BLINDING_STRATEGIES, UNBLINDABLE_STRATEGIES)
+    ACCEPTED_BLINDING_STRATEGIES)
 from picca.delta_extraction.utils_pk1d import spectral_resolution_desi, exp_diff_desi
 from picca.delta_extraction.utils import (
     ABSORBER_IGM, update_accepted_options, update_default_options)
@@ -23,12 +23,11 @@ from picca.delta_extraction.utils import (
 accepted_options = update_accepted_options(accepted_options, accepted_options_quasar_catalogue)
 accepted_options = update_accepted_options(
     accepted_options,
-    ["unblind", "use non-coadded spectra", "wave solution"])
+    ["use non-coadded spectra", "wave solution"])
 
 defaults = update_default_options(defaults, {
     "delta lambda": 0.8,
     "delta log lambda": 3e-4,
-    "unblind": True,
     "use non-coadded spectra": False,
     "wave solution": "lin",
 })
@@ -106,7 +105,6 @@ class DesiData(Data):
         super().__init__(config)
 
         # load variables from config
-        self.unblind = None
         self.use_non_coadded_spectra = None
         self.__parse_config(config)
 
@@ -141,10 +139,6 @@ class DesiData(Data):
         DataError upon missing required variables
         """
         # instance variables
-        self.unblind = config.getboolean("unblind")
-        if self.unblind is None:
-            raise DataError("Missing argument 'unblind' required by DesiData")
-
         self.use_non_coadded_spectra = config.getboolean(
             "use non-coadded spectra")
         if self.use_non_coadded_spectra is None:
@@ -196,14 +190,6 @@ class DesiData(Data):
                 self.blinding = "desi_y1"
             else:
                 self.blinding = "desi_y3"
-
-            if self.unblind:
-                if self.blinding not in UNBLINDABLE_STRATEGIES:
-                    raise DataError(
-                        "In DesiData: Requested unblinding but data requires blinding strategy "
-                        f"{self.blinding} and this strategy do not support "
-                        "unblinding. If you believe this is an error, contact "
-                        "picca developers")
 
         if self.blinding not in ACCEPTED_BLINDING_STRATEGIES:
             raise DataError(

--- a/py/picca/delta_extraction/data_catalogues/desi_data.py
+++ b/py/picca/delta_extraction/data_catalogues/desi_data.py
@@ -28,7 +28,7 @@ accepted_options = update_accepted_options(
 defaults = update_default_options(defaults, {
     "delta lambda": 0.8,
     "delta log lambda": 3e-4,
-    "unblind": False,
+    "unblind": True,
     "use non-coadded spectra": False,
     "wave solution": "lin",
 })

--- a/py/picca/delta_extraction/utils.py
+++ b/py/picca/delta_extraction/utils.py
@@ -88,8 +88,6 @@ ABSORBER_IGM = {
 
 ACCEPTED_BLINDING_STRATEGIES = [
     "none", "desi_m2", "desi_y1", "desi_y3"]
-# TODO: add tags here when we are allowed to unblind them
-UNBLINDABLE_STRATEGIES = ["none", "desi_m2", "desi_y1"]
 
 def class_from_string(class_name, module_name):
     """Return a class from a string. The class must be saved in a module

--- a/py/picca/delta_extraction/utils.py
+++ b/py/picca/delta_extraction/utils.py
@@ -89,7 +89,7 @@ ABSORBER_IGM = {
 ACCEPTED_BLINDING_STRATEGIES = [
     "none", "desi_m2", "desi_y1", "desi_y3"]
 # TODO: add tags here when we are allowed to unblind them
-UNBLINDABLE_STRATEGIES = []
+UNBLINDABLE_STRATEGIES = ["desi_m2", "desi_y1"]
 
 def class_from_string(class_name, module_name):
     """Return a class from a string. The class must be saved in a module

--- a/py/picca/delta_extraction/utils.py
+++ b/py/picca/delta_extraction/utils.py
@@ -89,7 +89,7 @@ ABSORBER_IGM = {
 ACCEPTED_BLINDING_STRATEGIES = [
     "none", "desi_m2", "desi_y1", "desi_y3"]
 # TODO: add tags here when we are allowed to unblind them
-UNBLINDABLE_STRATEGIES = ["desi_m2", "desi_y1"]
+UNBLINDABLE_STRATEGIES = ["none", "desi_m2", "desi_y1"]
 
 def class_from_string(class_name, module_name):
     """Return a class from a string. The class must be saved in a module

--- a/py/picca/tests/delta_extraction/data_tests.py
+++ b/py/picca/tests/delta_extraction/data_tests.py
@@ -747,19 +747,9 @@ class DataTest(AbstractTest):
 
         data = DesiHealpix(config["data"])
 
-        # run __parse_config with missing 'blinding'
-        config = ConfigParser()
-        config.read_dict({"data": {
-                        }})
-        expected_message = "Missing argument 'unblind' required by DesiData"
-        with self.assertRaises(DataError) as context_manager:
-            data._DesiData__parse_config(config["data"])
-        self.compare_error_message(context_manager, expected_message)
-
         # run __parse_config with missing 'use_non_coadded_spectra'
         config = ConfigParser()
         config.read_dict({"data": {
-            "unblind": "True",
                         }})
         expected_message = (
             "Missing argument 'use non-coadded spectra' required by DesiData"
@@ -949,34 +939,6 @@ class DataTest(AbstractTest):
         }})
         expected_message = (
             "Missing argument 'wave solution' required by Data"
-        )
-        with self.assertRaises(DataError) as context_manager:
-            DesiHealpix(config["data"])
-        self.compare_error_message(context_manager, expected_message)
-
-        # create a DesiHealpix with missing DesiData options
-        config = ConfigParser()
-        config.read_dict({"data": {
-            "catalogue": f"{THIS_DIR}/data/QSO_cat_fuji_dark_healpix.fits.gz",
-            "keep surveys": "all",
-            "input directory": f"{THIS_DIR}/data/",
-            "out dir": f"{THIS_DIR}/results/",
-            "use non-coadded spectra": False,
-            "num processors": 1,
-            "wave solution": "lin",
-            "delta lambda": 0.8,
-            "lambda max": 5500.0,
-            "lambda max rest frame": 1200.0,
-            "lambda min": 3600.0,
-            "lambda min rest frame": 1040.0,
-            "analysis type": "BAO 3D",
-            "minimum number pixels in forest": 50,
-            "rejection log file": "rejection.fits",
-            "minimal snr bao3d": 0.0,
-            "save format": "BinTableHDU",
-        }})
-        expected_message = (
-            "Missing argument 'unblind' required by DesiData"
         )
         with self.assertRaises(DataError) as context_manager:
             DesiHealpix(config["data"])


### PR DESCRIPTION
Removes the automatic blinding of Y1 correlations. Only picca_export is changed, with the rest of the pipeline unaffected.

Note that the blinding field in the header of exported correlations ('desi_y1') will remain, because we still need Vega to know about it for full-shape blinding.