### PR TITLE
fix raw_io for default delta_lambda

### DIFF
--- a/py/picca/raw_io.py
+++ b/py/picca/raw_io.py
@@ -482,8 +482,8 @@ def convert_transmission_to_deltas(obj_path, out_dir, in_dir=None, in_filenames=
     header['L_MAX'] = lambda_max
     header['LR_MIN'] = lambda_min_rest_frame
     header['LR_MAX'] = lambda_max_rest_frame
-    header['DEL_LL'] = delta_log_lambda
-    header['DEL_L'] = delta_lambda
+    header['DEL_LL'] = delta_x if not lin_spaced else None
+    header['DEL_L'] = delta_x if lin_spaced else None
     header['LINEAR'] = lin_spaced
     results.write(cols, names=names, header=header, extname='STATS')
     results.close()


### PR DESCRIPTION
Now how delta_lambda is written to the header is fixed. This was a problem when the user didn't provide delta_lambda and the default was used.