### PR TITLE
read version directly from version file

### DIFF
--- a/py/picca/delta_extraction/config.py
+++ b/py/picca/delta_extraction/config.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import git
 from git.exc import InvalidGitRepositoryError
 
+from picca._version import __version__ as picca_version
 from picca.delta_extraction.correction import Correction
 from picca.delta_extraction.data import Data
 from picca.delta_extraction.errors import ConfigError
@@ -24,7 +25,6 @@ try:
     git_hash = git.Repo(PICCA_BASE).head.object.hexsha
 except InvalidGitRepositoryError:  # pragma: no cover
     git_hash = metadata.metadata('picca')['Summary'].split(':')[-1]
-picca_version = metadata.metadata('picca')['Version']
 
 accepted_corrections_options = [
     "num corrections", "type {int}", "module name {int}"


### PR DESCRIPTION
This is a small change so that picca version is loaded from the _version.py file when loading the config. We discovered that depending on how picca was installed using pip the picca version saved in the .config.ini file might be bogus. This should not affect the git hash (also saved there).