### PR TITLE
Fixed documentation related to projection, and removed innecessary option

### DIFF
--- a/bin/picca_dmat.py
+++ b/bin/picca_dmat.py
@@ -197,11 +197,6 @@ def main(cmdargs):
         required=False,
         help='Equation of state of dark energy of fiducial LambdaCDM cosmology')
 
-    parser.add_argument('--no-project',
-                        action='store_true',
-                        required=False,
-                        help='Do not project out continuum fitting modes')
-
     parser.add_argument(
         '--remove-same-half-plate-close-pairs',
         action='store_true',
@@ -294,7 +289,6 @@ def main(cmdargs):
                                                   cf.z_ref,
                                                   cosmo,
                                                   max_num_spec=args.nspec,
-                                                  no_project=args.no_project,
                                                   nproc=args.nproc,
                                                   rebin_factor=args.rebin_factor,
                                                   z_min_qso=args.z_min_sources,
@@ -326,7 +320,6 @@ def main(cmdargs):
             cf.z_ref,
             cosmo,
             max_num_spec=args.nspec,
-            no_project=args.no_project,
             nproc=args.nproc,
             rebin_factor=args.rebin_factor,
             z_min_qso=args.z_min_sources,

--- a/py/picca/io.py
+++ b/py/picca/io.py
@@ -326,7 +326,7 @@ def read_deltas(in_dir,
         max_num_spec: int or None - default: None
             Maximum number of spectra to read
         no_project: bool - default: False
-            If True, project the deltas (see equation 5 of du Mas des Bourboux
+            If False, project the deltas (see equation 5 of du Mas des Bourboux
             et al. 2020)
         nproc: int - default: None
             Number of cpus for parallelization. If None, uses all available.


### PR DESCRIPTION
I have removed the --no-project option from picca_dmat, since it should have never been there. 

I have also fixed the documentation in io.py