### PR TITLE
Fix testing

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -57,7 +57,7 @@ jobs:
     # the following bit will save results tests as an artifact if [ci save] has been in the commit msg
     - name: Archive test results
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: test-results_v${{ matrix.python-version }}
         path: /tmp/last_run_picca_test
@@ -65,7 +65,7 @@ jobs:
 
     - name: Archive test results delta_extraction
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: test-results-de_v${{ matrix.python-version }}
         path: /home/runner/work/picca/picca/py/picca/tests/delta_extraction/results


### PR DESCRIPTION
There has been a deprecation on one of the github action modules storing artifacts when tests fail. That leads all tests to be failing before updating to a newer version which happens in this PR.