### PR TITLE
[bump minor] Change PyPI action

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -9,7 +9,10 @@ jobs:
   build-n-publish:
     name: Build and publish Picca 📦 to PyPI and TestPyPI
     runs-on: ubuntu-latest
-
+    environment: Release
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+      
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -34,11 +37,8 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository-url: https://test.pypi.org/legacy/
         
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This changes the github action to use Trusted Publisher functionality instead of a token linked to my account (https://docs.pypi.org/trusted-publishers/using-a-publisher/).