### PR TITLE
Redshift evolution in dmat

### DIFF
--- a/bin/picca_dmat.py
+++ b/bin/picca_dmat.py
@@ -150,11 +150,13 @@ def main(cmdargs):
         help=('Name of the absorption in picca.constants defining the redshift '
               'of the 2nd delta'))
 
-    parser.add_argument('--z-ref',
-                        type=float,
-                        default=2.25,
-                        required=False,
-                        help='Reference redshift')
+    # remove this option because it has no effect on the output
+    # and hence can lead to confusions
+    # parser.add_argument('--z-ref',
+    #                    type=float,
+    #                    default=2.25,
+    #                    required=False,
+    #                    help='Reference redshift')
 
     parser.add_argument(
         '--z-evol',
@@ -262,8 +264,18 @@ def main(cmdargs):
     cf.num_model_bins_r_par = args.np * args.coef_binning_model
     cf.num_model_bins_r_trans = args.nt * args.coef_binning_model
     cf.nside = args.nside
-    cf.z_ref = args.z_ref
-    cf.alpha = args.z_evol
+
+
+    # this value has no effect because it scales the weights that are both at the numerator and denominator of the estimator
+    # it is also used as a TEMPORARY VARIABLE to compute the distortion matrix scaling
+    # but this is rescaled to the actual effective redshift of the data (zeff) in the following
+    cf.z_ref = 12.
+
+    cf.alpha  = args.z_evol
+    # by default, for autocorrelations, we are setting cf.alpha2 to the same value
+    # it is overwritten by the value of args.z_evol2 if a second set of delta is given in input
+    cf.alpha2 = args.z_evol
+
     cf.reject = args.rej
     cf.lambda_abs = constants.ABSORBER_IGM[args.lambda_abs]
     cf.remove_same_half_plate_close_pairs = args.remove_same_half_plate_close_pairs
@@ -362,7 +374,7 @@ def main(cmdargs):
     dmat = np.array([item[1] for item in dmat_data]).sum(axis=0)
     r_par = np.array([item[2] for item in dmat_data]).sum(axis=0)
     r_trans = np.array([item[3] for item in dmat_data]).sum(axis=0)
-    z = np.array([item[4] for item in dmat_data]).sum(axis=0)
+    zeff = np.array([item[4] for item in dmat_data]).sum(axis=0)
     weights = np.array([item[5] for item in dmat_data]).sum(axis=0)
     num_pairs = np.array([item[6] for item in dmat_data]).sum(axis=0)
     num_pairs_used = np.array([item[7] for item in dmat_data]).sum(axis=0)
@@ -371,9 +383,18 @@ def main(cmdargs):
     w = weights > 0.
     r_par[w] /= weights[w]
     r_trans[w] /= weights[w]
-    z[w] /= weights[w]
+    zeff[w] /= weights[w]
+    mean_zeff = np.mean(zeff[w])
+
     w = weights_dmat > 0
     dmat[w] /= weights_dmat[w, None]
+
+    # now that we have the effective redshift of the input model considered
+    # for the distortion matrix, we do rescale the whole matrix
+    # we first consider the same effective redshift for all the model bins
+    zeff[:]   = mean_zeff
+    zfac = ((1+cf.z_ref)/(1+mean_zeff))**((cf.alpha-1)+(cf.alpha2-1))
+    dmat *= zfac
 
     # save results
     results = fitsio.FITS(args.out, 'rw', clobber=True)
@@ -463,7 +484,7 @@ def main(cmdargs):
                   units=['', ''],
                   header=header,
                   extname='DMAT')
-    results.write([r_par, r_trans, z],
+    results.write([r_par, r_trans, zeff],
                   names=['RP', 'RT', 'Z'],
                   comment=['R-parallel', 'R-transverse', 'Redshift'],
                   units=['h^-1 Mpc', 'h^-1 Mpc', ''],

--- a/bin/picca_dmat.py
+++ b/bin/picca_dmat.py
@@ -275,7 +275,7 @@ def main(cmdargs):
     # this value has no effect because it scales the weights that are both at the numerator and denominator of the estimator
     # it is also used as a TEMPORARY VARIABLE to compute the distortion matrix scaling
     # but this is rescaled to the actual effective redshift of the data (zeff) in the following
-    cf.z_ref = 12.
+    cf.z_ref = 2.25
 
     cf.alpha  = args.z_evol
     # by default, for autocorrelations, we are setting cf.alpha2 to the same value

--- a/bin/picca_xdmat.py
+++ b/bin/picca_xdmat.py
@@ -261,6 +261,7 @@ def main(cmdargs):
     xcf.nside = args.nside
     xcf.z_ref = args.z_ref
     xcf.alpha = args.z_evol_del
+    xcf.alpha_obj = args.z_evol_obj
     xcf.lambda_abs = constants.ABSORBER_IGM[args.lambda_abs]
     xcf.reject = args.rej
 

--- a/bin/picca_xdmat.py
+++ b/bin/picca_xdmat.py
@@ -273,7 +273,7 @@ def main(cmdargs):
     # this value has no effect because it scales the weights that are both at the numerator and denominator of the estimator
     # it is also used as a TEMPORARY VARIABLE to compute the distortion matrix scaling
     # but this is rescaled to the actual effective redshift of the data (zeff) in the following
-    xcf.z_ref = 12.
+    xcf.z_ref = 2.25
 
     xcf.alpha = args.z_evol_del
     xcf.alpha_obj = args.z_evol_obj

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -459,9 +459,11 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
             weights12 = weights1[i] * weights2[j]
             z = (z1[i] + z2[j]) / 2
             # default cf.alpha = args.z_evol = 2.9
+            # cf.alpha2 = cf.alpha for auto-correlation
+            # and cf.alpha2 = args.z_evol2 = 2.9 for cross-correlation with other deltas
             # this scale factor applies to all of the eta terms
             # it depends on i and j so it cannot be factored out
-            zfac = ((1+z1[i])*(1+z2[j])/(1+z_ref)**2)**(alpha-1)
+            zfac = (((1+z1[i])/(1+z_ref))**(alpha-1))*(((1+z2[j])/(1+z_ref))**(alpha2-1))
 
             bins_r_par = np.floor(
                 (r_par - r_par_min) / (r_par_max - r_par_min) * num_bins_r_par)
@@ -485,9 +487,7 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
             #-- Fill effective quantities (r_par, r_trans, z_eff, weight_eff)
             r_par_eff[model_bins] += weights12 * r_par
             r_trans_eff[model_bins] += weights12 * r_trans
-            # now it is z_ref and not the z value of the pair
-            # because of the 'zfac' term added to the eta terms
-            z_eff[model_bins] += weights12 * z_ref
+            z_eff[model_bins] += weights12 * z
             weight_eff[model_bins] += weights12
             weights_dmat[bins] += weights12
 
@@ -566,9 +566,11 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
         # second eta, first term: kronecker delta
         dmat_bin = model_bins + num_model_bins_r_par * num_model_bins_r_trans * bins
         # default cf.alpha = args.z_evol = 2.9
+        # cf.alpha2 = cf.alpha for auto-correlation
+        # and cf.alpha2 = args.z_evol2 = 2.9 for cross-correlation with other deltas
         # this scale factor was applied to all of the eta terms above
         # but not yet to the first term
-        zfac = ((1+z1[i])*(1+z2[j])/(1+z_ref)**2)**(alpha-1)
+        zfac = (((1+z1[i])/(1+z_ref))**(alpha-1))*(((1+z2[j])/(1+z_ref))**(alpha2-1))
         dmat[dmat_bin] += weights12 * zfac
 
         # rest of the terms

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -458,6 +458,10 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
 
             weights12 = weights1[i] * weights2[j]
             z = (z1[i] + z2[j]) / 2
+            # default cf.alpha = args.z_evol = 2.9
+            # this scale factor applies to all of the eta terms
+            # it depends on i and j so it cannot be factored out
+            zfac = ((1+z1[i])*(1+z2[j])/(1+z_ref)**2)**(alpha-1)
 
             bins_r_par = np.floor(
                 (r_par - r_par_min) / (r_par_max - r_par_min) * num_bins_r_par)
@@ -481,7 +485,9 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
             #-- Fill effective quantities (r_par, r_trans, z_eff, weight_eff)
             r_par_eff[model_bins] += weights12 * r_par
             r_trans_eff[model_bins] += weights12 * r_trans
-            z_eff[model_bins] += weights12 * z
+            # now it is z_ref and not the z value of the pair
+            # because of the 'zfac' term added to the eta terms
+            z_eff[model_bins] += weights12 * z_ref
             weight_eff[model_bins] += weights12
             weights_dmat[bins] += weights12
 
@@ -492,15 +498,15 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
 
             # first eta, first term: kronecker delta
             # second eta, second term: weight/sum(weights)
-            eta1[i + num_pixels1 * model_bins] += weights2[j] / sum_weights2
+            eta1[i + num_pixels1 * model_bins] += zfac *weights2[j] / sum_weights2
 
             # first eta, second term: weight/sum(weights)
             # second eta, first term: kronecker delta
-            eta2[j + num_pixels2 * model_bins] += weights1[i] / sum_weights1
+            eta2[j + num_pixels2 * model_bins] += zfac *weights1[i] / sum_weights1
 
             # first eta, second term: weight/sum(weights)
             # second eta, second term: weight/sum(weights)
-            eta5[model_bins] += weights12 / sum_weights1 / sum_weights2
+            eta5[model_bins] += zfac * weights12 / sum_weights1 / sum_weights2
 
             if order2 == 1:
                 # first eta, first term: kronecker delta
@@ -508,7 +514,7 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
                 #   weight*(Lambda-bar(Lambda))*(Lambda-bar(Lambda))/
                 #   sum(weight*(Lambda-bar(Lambda)**2))
                 eta3[i + num_pixels1 * model_bins] += (
-                    weights2[j] * log_lambda_minus_mean2[j] /
+                    zfac * weights2[j] * log_lambda_minus_mean2[j] /
                     sum_weights_square_log_lambda_minus_mean2)
 
                 # first eta, second term: weight/sum(weights)
@@ -516,7 +522,7 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
                 #   weight*(Lambda-bar(Lambda))*(Lambda-bar(Lambda))/
                 #   sum(weight*(Lambda-bar(Lambda)**2))
                 eta6[model_bins] += (
-                    weights1[i] / sum_weights1 *
+                    zfac * weights1[i] / sum_weights1 *
                     (weights2[j] * log_lambda_minus_mean2[j] /
                      sum_weights_square_log_lambda_minus_mean2))
             if order1 == 1:
@@ -525,14 +531,14 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
                 #   sum(weight*(Lambda-bar(Lambda)**2))
                 # second eta, first term: kronecker delta
                 eta4[j + num_pixels2 * model_bins] += (
-                    weights1[i] * log_lambda_minus_mean1[i] /
+                    zfac * weights1[i] * log_lambda_minus_mean1[i] /
                     sum_weights_square_log_lambda_minus_mean1)
                 # first eta, third term: (non-zero only for order=1)
                 #   weight*(Lambda-bar(Lambda))*(Lambda-bar(Lambda))/
                 #   sum(weight*(Lambda-bar(Lambda)**2))
                 # second eta, second term: weight/sum(weights)
                 eta7[model_bins] += (
-                    weights2[j] / sum_weights2 *
+                    zfac * weights2[j] / sum_weights2 *
                     (weights1[i] * log_lambda_minus_mean1[i] /
                      sum_weights_square_log_lambda_minus_mean1))
                 if order2 == 1:
@@ -543,7 +549,7 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
                     #   weight*(Lambda-bar(Lambda))*(Lambda-bar(Lambda))/
                     #   sum(weight*(Lambda-bar(Lambda)**2)
                     eta8[model_bins] += (
-                        weights1[i] * log_lambda_minus_mean1[i] * weights2[j] *
+                        zfac * weights1[i] * log_lambda_minus_mean1[i] * weights2[j] *
                         log_lambda_minus_mean2[j] /
                         sum_weights_square_log_lambda_minus_mean1 /
                         sum_weights_square_log_lambda_minus_mean2)
@@ -559,7 +565,12 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
         # first eta, first term: kronecker delta
         # second eta, first term: kronecker delta
         dmat_bin = model_bins + num_model_bins_r_par * num_model_bins_r_trans * bins
-        dmat[dmat_bin] += weights12
+        # default cf.alpha = args.z_evol = 2.9
+        # this scale factor was applied to all of the eta terms above
+        # but not yet to the first term
+        zfac = ((1+z1[i])*(1+z2[j])/(1+z_ref)**2)**(alpha-1)
+        dmat[dmat_bin] += weights12 * zfac
+
         # rest of the terms
         for k in unique_bins_model:
             dmat_bin = k + num_model_bins_r_par * num_model_bins_r_trans * bins

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -57,6 +57,9 @@ x_correlation = False
 ang_correlation = False
 remove_same_half_plate_close_pairs = False
 
+# variables for distortion matrix
+redshift_evolution_in_distortion_matrix = True
+
 # variables used in the 1D correlation function analysis
 num_pixels = None
 log_lambda_min = None
@@ -463,7 +466,10 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
             # and cf.alpha2 = args.z_evol2 = 2.9 for cross-correlation with other deltas
             # this scale factor applies to all of the eta terms
             # it depends on i and j so it cannot be factored out
-            zfac = (((1+z1[i])/(1+z_ref))**(alpha-1))*(((1+z2[j])/(1+z_ref))**(alpha2-1))
+            if redshift_evolution_in_distortion_matrix :
+                zfac = (((1+z1[i])/(1+z_ref))**(alpha-1))*(((1+z2[j])/(1+z_ref))**(alpha2-1))
+            else :
+                zfac = 1.
 
             bins_r_par = np.floor(
                 (r_par - r_par_min) / (r_par_max - r_par_min) * num_bins_r_par)
@@ -570,7 +576,10 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
         # and cf.alpha2 = args.z_evol2 = 2.9 for cross-correlation with other deltas
         # this scale factor was applied to all of the eta terms above
         # but not yet to the first term
-        zfac = (((1+z1[i])/(1+z_ref))**(alpha-1))*(((1+z2[j])/(1+z_ref))**(alpha2-1))
+        if redshift_evolution_in_distortion_matrix :
+            zfac = (((1+z1[i])/(1+z_ref))**(alpha-1))*(((1+z2[j])/(1+z_ref))**(alpha2-1))
+        else :
+            zfac = 1
         dmat[dmat_bin] += weights12 * zfac
 
         # rest of the terms

--- a/py/picca/tests/test_3_cor.py
+++ b/py/picca/tests/test_3_cor.py
@@ -328,6 +328,8 @@ class TestCor(AbstractTest):
         cmd += " --rej 0.99"
         cmd += " --nproc 1"
         cmd += ' --remove-same-half-plate-close-pairs'
+        cmd += ' --no-redshift-evolution'
+
         print(repr(cmd))
         picca.bin.picca_dmat.main(cmd.split()[1:])
 
@@ -497,6 +499,8 @@ class TestCor(AbstractTest):
         cmd += " --nproc 1"
         cmd += ' --remove-same-half-plate-close-pairs'
         cmd += " --unfold-cf"
+        cmd += ' --no-redshift-evolution'
+
         print(repr(cmd))
         picca.bin.picca_dmat.main(cmd.split()[1:])
 
@@ -542,7 +546,7 @@ class TestCor(AbstractTest):
             self.compare_fits(path1, path2, "picca_metal_dmat.py")
 
         return
-    
+
     def test_fast_metal_dmat_cross(self):
         """
             Test metal cross distortion matrix
@@ -666,6 +670,7 @@ class TestCor(AbstractTest):
         cmd += " --rej 0.99"
         cmd += " --nproc 1"
         cmd += " --z-evol-obj 1."
+        cmd += ' --no-redshift-evolution'
         print(repr(cmd))
         picca.bin.picca_xdmat.main(cmd.split()[1:])
 
@@ -880,6 +885,8 @@ class TestCor(AbstractTest):
         cmd += " --z-cut-max 2.3"
         cmd += " --z-min-sources 2.3"
         cmd += " --z-max-sources 2.5"
+        cmd += ' --no-redshift-evolution'
+
         print(repr(cmd))
         picca.bin.picca_dmat.main(cmd.split()[1:])
 
@@ -957,7 +964,7 @@ class TestCor(AbstractTest):
             self.compare_fits(path1, path2, "picca_fast_metal_dmat.py")
 
         return
-    
+
     def test_wick_zcuts(self):
         """
             Test wick covariances
@@ -1053,6 +1060,8 @@ class TestCor(AbstractTest):
         cmd += " --z-cut-max 2.3"
         cmd += " --z-min-sources 2.3"
         cmd += " --z-max-sources 2.5"
+        cmd += ' --no-redshift-evolution'
+
         print(repr(cmd))
         picca.bin.picca_dmat.main(cmd.split()[1:])
 
@@ -1102,7 +1111,7 @@ class TestCor(AbstractTest):
             self.compare_fits(path1, path2, "picca_metal_dmat.py")
 
         return
-    
+
     def test_fast_metal_dmat_cross_zcuts(self):
         """
             Test metal cross distortion matrix
@@ -1225,6 +1234,7 @@ class TestCor(AbstractTest):
         cmd += " --z-cut-max 2.3"
         cmd += " --z-min-sources 2.3"
         cmd += " --z-max-sources 2.5"
+        cmd += ' --no-redshift-evolution'
         print(repr(cmd))
         picca.bin.picca_xdmat.main(cmd.split()[1:])
 

--- a/py/picca/xcf.py
+++ b/py/picca/xcf.py
@@ -52,6 +52,9 @@ lock = None
 cosmo = None
 ang_correlation = False
 
+# variables for distortion matrix
+redshift_evolution_in_distortion_matrix = True
+
 # variables used in the wick covariance matrix computation
 get_variance_1d = {}
 xi_1d = {}
@@ -390,7 +393,10 @@ def compute_dmat_forest_pairs_fast(log_lambda1, r_comov1, dist_m1, z1, weights1,
             # it depends on i and j so it cannot be factored out
             # HERE WE ARE ASSUMING THAT ALPHA_OBJ IS FOR Z2 AND NOT Z1
             # (see call in xcf.compute_dmat)
-            zfac = (((1+z1[i])/(1+z_ref))**(alpha-1)) * (((1+z2[j])/(1+z_ref))**(alpha_obj-1))
+            if redshift_evolution_in_distortion_matrix :
+                zfac = (((1+z1[i])/(1+z_ref))**(alpha-1)) * (((1+z2[j])/(1+z_ref))**(alpha_obj-1))
+            else :
+                zfac = 1
 
             bins_r_par = np.floor(
                 (r_par - r_par_min) / (r_par_max - r_par_min) * num_bins_r_par)
@@ -453,7 +459,10 @@ def compute_dmat_forest_pairs_fast(log_lambda1, r_comov1, dist_m1, z1, weights1,
         # but not yet to the first term
         # HERE WE ARE ASSUMING THAT ALPHA_OBJ IS FOR Z2 AND NOT Z1
         # (see call in xcf.compute_dmat)
-        zfac = (((1+z1[i])/(1+z_ref))**(alpha-1)) * (((1+z2[j])/(1+z_ref))**(alpha_obj-1))
+        if redshift_evolution_in_distortion_matrix :
+            zfac = (((1+z1[i])/(1+z_ref))**(alpha-1)) * (((1+z2[j])/(1+z_ref))**(alpha_obj-1))
+        else :
+            zfac = 1
         dmat[dmat_bin] +=  zfac *weights12
         # rest of the terms
         for k in unique_bins_model:

--- a/py/picca/xcf.py
+++ b/py/picca/xcf.py
@@ -414,9 +414,7 @@ def compute_dmat_forest_pairs_fast(log_lambda1, r_comov1, dist_m1, z1, weights1,
             #-- Fill effective quantities (r_par, r_trans, z_eff, weight_eff)
             r_par_eff[model_bins] += weights12 * r_par
             r_trans_eff[model_bins] += weights12 * r_trans
-            # now it is z_ref and not the z value of the pair
-            # because of the 'zfac' term added to the eta terms
-            z_eff[model_bins] += weights12 * z_ref
+            z_eff[model_bins] += weights12 * z
             weight_eff[model_bins] += weights12
             weights_dmat[bins] += weights12
 

--- a/py/picca/xcf.py
+++ b/py/picca/xcf.py
@@ -386,6 +386,12 @@ def compute_dmat_forest_pairs_fast(log_lambda1, r_comov1, dist_m1, z1, weights1,
             weights12 = weights1[i] * weights2[j]
             z = (z1[i] + z2[j]) / 2
 
+            # this scale factor applies to all of the eta terms
+            # it depends on i and j so it cannot be factored out
+            # HERE WE ARE ASSUMING THAT ALPHA_OBJ IS FOR Z2 AND NOT Z1
+            # (see call in xcf.compute_dmat)
+            zfac = (((1+z1[i])/(1+z_ref))**(alpha-1)) * (((1+z2[j])/(1+z_ref))**(alpha_obj-1))
+
             bins_r_par = np.floor(
                 (r_par - r_par_min) / (r_par_max - r_par_min) * num_bins_r_par)
             bins_r_trans = np.floor(r_trans / r_trans_max * num_bins_r_trans)
@@ -408,7 +414,9 @@ def compute_dmat_forest_pairs_fast(log_lambda1, r_comov1, dist_m1, z1, weights1,
             #-- Fill effective quantities (r_par, r_trans, z_eff, weight_eff)
             r_par_eff[model_bins] += weights12 * r_par
             r_trans_eff[model_bins] += weights12 * r_trans
-            z_eff[model_bins] += weights12 * z
+            # now it is z_ref and not the z value of the pair
+            # because of the 'zfac' term added to the eta terms
+            z_eff[model_bins] += weights12 * z_ref
             weight_eff[model_bins] += weights12
             weights_dmat[bins] += weights12
 
@@ -419,14 +427,14 @@ def compute_dmat_forest_pairs_fast(log_lambda1, r_comov1, dist_m1, z1, weights1,
 
             # first eta, second term: weight/sum(weights)
             # second eta, first term: kronecker delta
-            eta2[j + num_pixels2 * model_bins] += weights1[i] / sum_weights1
+            eta2[j + num_pixels2 * model_bins] +=  zfac *weights1[i] / sum_weights1
 
             if order1 == 1:
                 # first eta, third term: (non-zero only for order=1)
                 #   weight*(Lambda-bar(Lambda))*(Lambda-bar(Lambda))/
                 #   sum(weight*(Lambda-bar(Lambda)**2))
                 # second eta, first term: kronecker delta
-                eta4[j + num_pixels2 * model_bins] += (
+                eta4[j + num_pixels2 * model_bins] +=  zfac *(
                     weights1[i] * log_lambda_minus_mean1[i] /
                     sum_weights_square_log_lambda_minus_mean1)
 
@@ -441,7 +449,14 @@ def compute_dmat_forest_pairs_fast(log_lambda1, r_comov1, dist_m1, z1, weights1,
         # first eta, first term: kronecker delta
         # second eta, first term: kronecker delta
         dmat_bin = model_bins + num_model_bins_r_par * num_model_bins_r_trans * bins
-        dmat[dmat_bin] += weights12
+
+
+        # this scale factor was applied to all of the eta terms above
+        # but not yet to the first term
+        # HERE WE ARE ASSUMING THAT ALPHA_OBJ IS FOR Z2 AND NOT Z1
+        # (see call in xcf.compute_dmat)
+        zfac = (((1+z1[i])/(1+z_ref))**(alpha-1)) * (((1+z2[j])/(1+z_ref))**(alpha_obj-1))
+        dmat[dmat_bin] +=  zfac *weights12
         # rest of the terms
         for k in unique_bins_model:
             dmat_bin = k + num_model_bins_r_par * num_model_bins_r_trans * bins


### PR DESCRIPTION
Adding redshift evolution in the distortion matrix calculation both for auto and cross-correlation.

The matrix elements are scaled with ((1+z1)/(1+zref))^(alpha-1)*((1+z2)/(1+zref))^(alpha2-1).
- this redshift scaling coefficient is part of the contribution of each pair in the numerical integrals (so it is properly weighted).
- alpha, alpha2 are the bias evolution power law indices.
- alpha2=alpha=2.9 for lya auto, alpha2=alpha_obj=1.44 in lyaxQSO. 
- can be set to different values with options in the scripts.
- zref is computed from the data set. It is returned in the ATTRI HDU table column Z as it was before. 
- this redshift column Z is read by vega and defines the redshift of the undistorted model (that is then multiplied by the distortion matrix).

This modification to the distortion matrix improves the fit of colore mocks.