### PR TITLE
Zerr cuts

### DIFF
--- a/bin/picca_cf.py
+++ b/bin/picca_cf.py
@@ -93,13 +93,17 @@ def main(cmdargs):
                         type=float,
                         default=None,
                         required=False,
-                        help="Cut on angular distance in degrees (pixels pairs within this distance and also fulfilling zerr-cut-km will be discarded).")
+                        help=('Angular cut (in degrees) between a pixel and '
+                              'the background quasar of the other pixel (to '
+                              'avoid contamination from redshift errors).'))
     
-    parser.add_argument('--zerr-cut-km',
+    parser.add_argument('--zerr-cut-kms',
                         type=float,
                         default=None,
                         required=False,
-                        help="Cut on redshift difference in in km/s (pixels pairs within this difference and also fulfilling zerr-cut-deg will be discarded).")
+                        help=('Velocity cut (in km/s) between a pixel and the '
+                              'background quasar of the other pixel (to avoid '
+                              'contamination from redshift errors).'))
 
     parser.add_argument('--z-cut-min',
                         type=float,
@@ -262,12 +266,12 @@ def main(cmdargs):
     cf.lambda_abs = constants.ABSORBER_IGM[args.lambda_abs]
     cf.remove_same_half_plate_close_pairs = args.remove_same_half_plate_close_pairs
 
-    if (args.zerr_cut_deg is None) != (args.zerr_cut_km is None):
-        raise ValueError("Options --zerr-cut-deg and --zerr-cut-km must be "
+    if (args.zerr_cut_deg is None) != (args.zerr_cut_kms is None):
+        raise ValueError("Options --zerr-cut-deg and --zerr-cut-kms must be "
                          "specified together")
 
     cf.zerr_cut_deg = args.zerr_cut_deg
-    cf.zerr_cut_km = args.zerr_cut_km
+    cf.zerr_cut_kms = args.zerr_cut_kms
 
 
     # read blinding keyword

--- a/bin/picca_cf.py
+++ b/bin/picca_cf.py
@@ -88,6 +88,18 @@ def main(cmdargs):
                         default=50,
                         required=False,
                         help='Number of r-transverse bins')
+    
+    parser.add_argument('--zerr-cut-deg',
+                        type=float,
+                        default=None,
+                        required=False,
+                        help="Cut on angular distance in degrees (pixels pairs within this distance and also fulfilling zerr-cut-km will be discarded).")
+    
+    parser.add_argument('--zerr-cut-km',
+                        type=float,
+                        default=None,
+                        required=False,
+                        help="Cut on redshift difference in in km/s (pixels pairs within this difference and also fulfilling zerr-cut-deg will be discarded).")
 
     parser.add_argument('--z-cut-min',
                         type=float,
@@ -249,6 +261,14 @@ def main(cmdargs):
     cf.alpha = args.z_evol
     cf.lambda_abs = constants.ABSORBER_IGM[args.lambda_abs]
     cf.remove_same_half_plate_close_pairs = args.remove_same_half_plate_close_pairs
+
+    if (args.zerr_cut_deg is None) != (args.zerr_cut_km is None):
+        raise ValueError("Options --zerr-cut-deg and --zerr-cut-km must be "
+                         "specified together")
+
+    cf.zerr_cut_deg = args.zerr_cut_deg
+    cf.zerr_cut_km = args.zerr_cut_km
+
 
     # read blinding keyword
     blinding = io.read_blinding(args.in_dir)

--- a/bin/picca_dmat.py
+++ b/bin/picca_dmat.py
@@ -100,6 +100,22 @@ def main(cmdargs):
         help=('Coefficient multiplying np and nt to get finner binning for the '
               'model'))
 
+    parser.add_argument('--zerr-cut-deg',
+                        type=float,
+                        default=None,
+                        required=False,
+                        help=('Angular cut (in degrees) between a pixel and '
+                              'the background quasar of the other pixel (to '
+                              'avoid contamination from redshift errors).'))
+    
+    parser.add_argument('--zerr-cut-kms',
+                        type=float,
+                        default=None,
+                        required=False,
+                        help=('Velocity cut (in km/s) between a pixel and the '
+                              'background quasar of the other pixel (to avoid '
+                              'contamination from redshift errors).'))
+
     parser.add_argument(
         '--z-cut-min',
         type=float,
@@ -285,6 +301,13 @@ def main(cmdargs):
     cf.reject = args.rej
     cf.lambda_abs = constants.ABSORBER_IGM[args.lambda_abs]
     cf.remove_same_half_plate_close_pairs = args.remove_same_half_plate_close_pairs
+
+    if (args.zerr_cut_deg is None) != (args.zerr_cut_kms is None):
+        raise ValueError("Options --zerr-cut-deg and --zerr-cut-kms must be "
+                         "specified together")
+
+    cf.zerr_cut_deg = args.zerr_cut_deg
+    cf.zerr_cut_kms = args.zerr_cut_kms
 
     # read blinding keyword
     blinding = io.read_blinding(args.in_dir)

--- a/bin/picca_xcf.py
+++ b/bin/picca_xcf.py
@@ -112,21 +112,21 @@ def main(cmdargs):
                         default=10,
                         required=False,
                         help='Max redshift for object field')
-    
+
     parser.add_argument('--zerr-cut-deg',
                         type=float,
                         default=None,
                         required=False,
-                        help=('Angular cut (in degrees) between a quasar and '
-                              'the background quasar of the pixel (to avoid '
+                        help=('Angular cut (in degrees) between the foreground '
+                              'and the background quasars (to avoid '
                               'contamination from redshift errors).'))
 
     parser.add_argument('--zerr-cut-kms',
                         type=float,
                         default=None,
                         required=False,
-                        help=('Velocity cut (in km/s) between a quasar and the '
-                              'background quasar of the pixel (to avoid '
+                        help=('Velocity cut (in km/s) between the foreground '
+                              'and the background quasars (to avoid '
                               'contamination from redshift errors).'))
 
     parser.add_argument(

--- a/bin/picca_xcf.py
+++ b/bin/picca_xcf.py
@@ -112,7 +112,19 @@ def main(cmdargs):
                         default=10,
                         required=False,
                         help='Max redshift for object field')
-
+    
+    parser.add_argument('--zerr-cut-deg',
+                        type=float,
+                        default=None,
+                        required=False,
+                        help="Cut on angular distance in degrees (pixels pairs within this distance and also fulfilling zerr-cut-km will be discarded).")
+    
+    parser.add_argument('--zerr-cut-km',
+                        type=float,
+                        default=None,
+                        required=False,
+                        help="Cut on redshift difference in in km/s (pixels pairs within this difference and also fulfilling zerr-cut-deg will be discarded).")
+    
     parser.add_argument(
         '--z-cut-min',
         type=float,
@@ -267,6 +279,13 @@ def main(cmdargs):
     xcf.num_bins_r_trans = args.nt
     xcf.nside = args.nside
     xcf.lambda_abs = constants.ABSORBER_IGM[args.lambda_abs]
+
+    if (args.zerr_cut_deg is None) != (args.zerr_cut_km is None):
+        raise ValueError("Options --zerr-cut-deg and --zerr-cut-km must be "
+                         "specified together")
+    
+    xcf.zerr_cut_deg = args.zerr_cut_deg
+    xcf.zerr_cut_km = args.zerr_cut_km
 
     # read blinding keyword
     blinding = io.read_blinding(args.in_dir)

--- a/bin/picca_xcf.py
+++ b/bin/picca_xcf.py
@@ -117,14 +117,18 @@ def main(cmdargs):
                         type=float,
                         default=None,
                         required=False,
-                        help="Cut on angular distance in degrees (pixels pairs within this distance and also fulfilling zerr-cut-km will be discarded).")
-    
-    parser.add_argument('--zerr-cut-km',
+                        help=('Angular cut (in degrees) between a quasar and '
+                              'the background quasar of the pixel (to avoid '
+                              'contamination from redshift errors).'))
+
+    parser.add_argument('--zerr-cut-kms',
                         type=float,
                         default=None,
                         required=False,
-                        help="Cut on redshift difference in in km/s (pixels pairs within this difference and also fulfilling zerr-cut-deg will be discarded).")
-    
+                        help=('Velocity cut (in km/s) between a quasar and the '
+                              'background quasar of the pixel (to avoid '
+                              'contamination from redshift errors).'))
+
     parser.add_argument(
         '--z-cut-min',
         type=float,
@@ -280,12 +284,12 @@ def main(cmdargs):
     xcf.nside = args.nside
     xcf.lambda_abs = constants.ABSORBER_IGM[args.lambda_abs]
 
-    if (args.zerr_cut_deg is None) != (args.zerr_cut_km is None):
-        raise ValueError("Options --zerr-cut-deg and --zerr-cut-km must be "
+    if (args.zerr_cut_deg is None) != (args.zerr_cut_kms is None):
+        raise ValueError("Options --zerr-cut-deg and --zerr-cut-kms must be "
                          "specified together")
     
     xcf.zerr_cut_deg = args.zerr_cut_deg
-    xcf.zerr_cut_km = args.zerr_cut_km
+    xcf.zerr_cut_kms = args.zerr_cut_kms
 
     # read blinding keyword
     blinding = io.read_blinding(args.in_dir)

--- a/bin/picca_xdmat.py
+++ b/bin/picca_xdmat.py
@@ -125,16 +125,16 @@ def main(cmdargs):
                         type=float,
                         default=None,
                         required=False,
-                        help=('Angular cut (in degrees) between a pixel and '
-                              'the background quasar of the other pixel (to '
-                              'avoid contamination from redshift errors).'))
+                        help=('Angular cut (in degrees) between the foreground '
+                              'and the background quasars (to avoid '
+                              'contamination from redshift errors).'))
     
     parser.add_argument('--zerr-cut-kms',
                         type=float,
                         default=None,
                         required=False,
-                        help=('Velocity cut (in km/s) between a pixel and the '
-                              'background quasar of the other pixel (to avoid '
+                        help=('Velocity cut (in km/s) between the foreground '
+                              'and the background quasars (to avoid '
                               'contamination from redshift errors).'))
 
     parser.add_argument(

--- a/bin/picca_xdmat.py
+++ b/bin/picca_xdmat.py
@@ -121,6 +121,22 @@ def main(cmdargs):
                         required=False,
                         help='Max redshift for object field')
 
+    parser.add_argument('--zerr-cut-deg',
+                        type=float,
+                        default=None,
+                        required=False,
+                        help=('Angular cut (in degrees) between a pixel and '
+                              'the background quasar of the other pixel (to '
+                              'avoid contamination from redshift errors).'))
+    
+    parser.add_argument('--zerr-cut-kms',
+                        type=float,
+                        default=None,
+                        required=False,
+                        help=('Velocity cut (in km/s) between a pixel and the '
+                              'background quasar of the other pixel (to avoid '
+                              'contamination from redshift errors).'))
+
     parser.add_argument(
         '--z-cut-min',
         type=float,
@@ -279,6 +295,13 @@ def main(cmdargs):
     xcf.alpha_obj = args.z_evol_obj
     xcf.lambda_abs = constants.ABSORBER_IGM[args.lambda_abs]
     xcf.reject = args.rej
+
+    if (args.zerr_cut_deg is None) != (args.zerr_cut_kms is None):
+        raise ValueError("Options --zerr-cut-deg and --zerr-cut-kms must be "
+                         "specified together")
+    
+    xcf.zerr_cut_deg = args.zerr_cut_deg
+    xcf.zerr_cut_kms = args.zerr_cut_kms
 
     # read blinding keyword
     blinding = io.read_blinding(args.in_dir)

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -412,19 +412,28 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
         if weights1[i] == 0:
             continue
 
-        raise ValueError("CRASH (UPDATE THIS)")
-
         if (zerr_cut_deg is not None) and (ang < zerr_cut_deg*np.pi/180.):
-            continue
+            # mean redshift of quasar-pixel pair
+            z_qF = 0.5 * (z1[i] + z_qso_2)
+            # velocity separation between pixel 1 and backgroud quasar 2
+            dv_kms = np.abs(z1[i] - z_qso_2)/(1 + z_qF)
+            dv_kms *= constants.SPEED_LIGHT
+            if dv_kms < zerr_cut_kms:
+                continue
 
         for j in range(z2.size):
             if weights2[j] == 0:
                 continue
 
-            if zerr_cut_kms is not None:
-                if (np.abs(z1[i] - z_qso_2)/(z2 + 1)*constants.SPEED_LIGHT < zerr_cut_kms) or (np.abs(z2[j] - z_qso_1)/(z1+1)*constants.SPEED_LIGHT < zerr_cut_kms):
+            if (zerr_cut_deg is not None) and (ang < zerr_cut_deg*np.pi/180.):
+                # mean redshift of quasar-pixel pair
+                z_qF = 0.5 * (z2[j] + z_qso_1)
+                # velocity separation between pixel 1 and backgroud quasar 2
+                dv_kms = np.abs(z2[j] - z_qso_1)/(1 + z_qF)
+                dv_kms *= constants.SPEED_LIGHT
+                if dv_kms < zerr_cut_kms:
                     continue
-
+            
             r_par = (r_comov1[i] - r_comov2[j]) * np.cos(ang / 2)
             r_trans = (dist_m1[i] + dist_m2[j]) * np.sin(ang / 2)
             if not x_correlation:

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -492,9 +492,29 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
     for i in range(z1.size):
         if weights1[i] == 0:
             continue
+
+        if (zerr_cut_deg is not None) and (ang < zerr_cut_deg*np.pi/180.):
+            # mean redshift of quasar-pixel pair
+            z_qF = 0.5 * (z1[i] + z_qso_2)
+            # velocity separation between pixel 1 and backgroud quasar 2
+            dv_kms = np.abs(z1[i] - z_qso_2)/(1 + z_qF)
+            dv_kms *= constants.SPEED_LIGHT
+            if dv_kms < zerr_cut_kms:
+                continue
+
         for j in range(z2.size):
             if weights2[j] == 0:
                 continue
+
+            if (zerr_cut_deg is not None) and (ang < zerr_cut_deg*np.pi/180.):
+                # mean redshift of quasar-pixel pair
+                z_qF = 0.5 * (z2[j] + z_qso_1)
+                # velocity separation between pixel 1 and backgroud quasar 2
+                dv_kms = np.abs(z2[j] - z_qso_1)/(1 + z_qF)
+                dv_kms *= constants.SPEED_LIGHT
+                if dv_kms < zerr_cut_kms:
+                    continue
+
             r_par = (r_comov1[i] - r_comov2[j]) * np.cos(ang / 2)
             r_trans = (dist_m1[i] + dist_m2[j]) * np.sin(ang / 2)
             if not x_correlation:

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -36,7 +36,7 @@ ang_max = None
 nside = None
 
 zerr_cut_deg = None
-zerr_cut_km = None
+zerr_cut_kms = None
 
 counter = None
 num_data = None
@@ -264,8 +264,8 @@ def compute_xi_forest_pairs_fast(z1, r_comov1, dist_m1, weights1, delta1, z_qso_
             if weights2[j] == 0:
                 continue
 
-            if zerr_cut_km is not None:
-                if (np.abs(z1[i] - z_qso_2) < zerr_cut_km) or (np.abs(z2[j] - z_qso_1) < zerr_cut_km):
+            if zerr_cut_kms is not None:
+                if (np.abs(z1[i] - z_qso_2) < zerr_cut_kms) or (np.abs(z2[j] - z_qso_1) < zerr_cut_kms):
                     continue
 
             if ang_correlation:
@@ -408,8 +408,8 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
             if weights2[j] == 0:
                 continue
 
-            if zerr_cut_km is not None:
-                if (np.abs(z1[i] - z_qso_2)/(z2 + 1)*constants.SPEED_LIGHT < zerr_cut_km) or (np.abs(z2[j] - z_qso_1)/(z1+1)*constants.SPEED_LIGHT < zerr_cut_km):
+            if zerr_cut_kms is not None:
+                if (np.abs(z1[i] - z_qso_2)/(z2 + 1)*constants.SPEED_LIGHT < zerr_cut_kms) or (np.abs(z2[j] - z_qso_1)/(z1+1)*constants.SPEED_LIGHT < zerr_cut_kms):
                     continue
 
             r_par = (r_comov1[i] - r_comov2[j]) * np.cos(ang / 2)

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -223,7 +223,7 @@ def compute_xi_forest_pairs_fast(z1, r_comov1, dist_m1, weights1, delta1, z_qso_
             Pixel weights for forest 1
         delta1: array of float
             Delta field for forest 1
-        z_qso_1: array of float
+        z_qso_1: float
             Redshift of QSO 1
         z2: array of float
             Redshift of pixel 2
@@ -235,9 +235,9 @@ def compute_xi_forest_pairs_fast(z1, r_comov1, dist_m1, weights1, delta1, z_qso_
             Pixel weights for forest 2
         delta2: array of float
             Delta field for forest 2
-        z_qso_2: array of float
+        z_qso_2: float
             Redshift of QSO 2
-        ang: array of float
+        ang: float
             Angular separation between pixels in forests 1 and 2
         same_half_plate: bool
             Flag to determine if the two forests are on the same half plate
@@ -258,16 +258,27 @@ def compute_xi_forest_pairs_fast(z1, r_comov1, dist_m1, weights1, delta1, z_qso_
             continue
 
         if (zerr_cut_deg is not None) and (ang < zerr_cut_deg*np.pi/180.):
-            continue
-
-        for j in range(z2.size): #@ This is where I want to add something.
-            if weights2[j] == 0:
+            # mean redshift of quasar-pixel pair
+            z_qF = 0.5 * (z1[i] + z_qso_2)
+            # velocity separation between pixel 1 and backgroud quasar 2
+            dv_kms = np.abs(z1[i] - z_qso_2)/(1 + z_qF)
+            dv_kms *= constants.SPEED_LIGHT
+            if dv_kms < zerr_cut_kms:
                 continue
 
-            if zerr_cut_kms is not None:
-                if (np.abs(z1[i] - z_qso_2) < zerr_cut_kms) or (np.abs(z2[j] - z_qso_1) < zerr_cut_kms):
+        for j in range(z2.size): 
+            if weights2[j] == 0:
+                continue
+            
+            if (zerr_cut_deg is not None) and (ang < zerr_cut_deg*np.pi/180.):
+                # mean redshift of quasar-pixel pair
+                z_qF = 0.5 * (z2[j] + z_qso_1)
+                # velocity separation between pixel 1 and backgroud quasar 2
+                dv_kms = np.abs(z2[j] - z_qso_1)/(1 + z_qF)
+                dv_kms *= constants.SPEED_LIGHT
+                if dv_kms < zerr_cut_kms:
                     continue
-
+            
             if ang_correlation:
                 r_par = r_comov1[i] / r_comov2[j]
                 if not x_correlation and r_par < 1.:
@@ -400,6 +411,8 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
     for i in range(z1.size):
         if weights1[i] == 0:
             continue
+
+        raise ValueError("CRASH (UPDATE THIS)")
 
         if (zerr_cut_deg is not None) and (ang < zerr_cut_deg*np.pi/180.):
             continue

--- a/py/picca/xcf.py
+++ b/py/picca/xcf.py
@@ -34,6 +34,9 @@ z_cut_min = None
 ang_max = None
 nside = None
 
+zerr_cut_deg = None
+zerr_cut_km = None
+
 counter = None
 num_data = None
 
@@ -87,6 +90,13 @@ def fill_neighs(healpixs):
             ]
             ang = delta.get_angle_between(neighbours)
             w = ang < ang_max
+
+            if zerr_cut_deg is not None:
+                w &= (ang > zerr_cut_deg*np.pi/180.)
+                w &= np.array([
+                    abs(delta.z_qso - obj.z_qso) for obj in neighbours
+                ])/(delta.z_qso+1) * constants.SPEED_LIGHT > zerr_cut_km
+
             if not ang_correlation:
                 r_comov = np.array([obj.r_comov for obj in neighbours])
                 w &= (delta.r_comov[0] - r_comov) * np.cos(ang / 2.) < r_par_max


### PR DESCRIPTION
Implemented the addition of two cuts to study the effect of redshift errors (`zerr-cut-deg` and `zerr-cut-kms`). The meaning of these two parameters differs depending on whether we measure the auto-correlation or the cross-correlation.

For the cross-correlation:
- `zerr-cut-deg`: Related to the angle between the skewer and the quasar object.
- `zerr-cut-kms`: Related to the radial velocity difference between the skewer's quasar and the object.
Skewers from quasar pairs where (θ < zerr-cut-deg) and (v < zerr-cut-kms) are removed from the computation.

For the cross-correlation:
- `zerr-cut-deg`: Related to the angle between skewers.
- `zerr-cut-kms`: Related to the radial velocity difference between a pixel in one skewer vs the other skewer's quasar.
pixel pairs where (θ < zerr-cut-deg) and (v < zerr-cut-kms) are removed from the computation.

Opened this draft pull request to discuss the election of variable names, behavior or any other issue.