### PR TITLE
update pyproject to allow pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 [tool.setuptools.dynamic]
 version = {attr = "picca.__version__"}
-readme = {file = "README.md"}
+readme = {file = "README.md", content-type = "text/markdown"}
 dependencies = {file = "requirements.txt"}
 
 [project.urls]


### PR DESCRIPTION
Fixes the Pypi uploads by explicitely telling that the Readme is markdown and not rst.