### PR TITLE
Binning CF in r, mu grid

### DIFF
--- a/py/picca/bin/picca_cf.py
+++ b/py/picca/bin/picca_cf.py
@@ -93,10 +93,6 @@ def main(cmdargs=None):
                               ' nt becomes r bins. rp min max is always 0, 1')
                         )
 
-    parser.add_argument('--nell', type=int, default=5,
-                        help=('Number of even multipoles to calculate'
-                              ' if rmu-binning')
-                        )
     parser.add_argument('--zerr-cut-deg',
                         type=float,
                         default=None,

--- a/py/picca/bin/picca_cf.py
+++ b/py/picca/bin/picca_cf.py
@@ -481,15 +481,21 @@ def main(cmdargs=None):
         r_ell = np.sum(sum_weights * r_trans, 0) / sum_sum_weights
         z_ell = np.sum(sum_weights * z, 0) / sum_sum_weights
         num_pairs_ell = num_pairs.reshape(args.np, args.nt).sum(0)
+        ells = 2 * np.arange(args.nell)
+        rp_ell = np.repeat(ells, args.nt)
+        r_ell = np.tile(r_ell, args.nell)
+        z_ell = np.tile(z_ell, args.nell)
+        num_pairs_ell = np.tile(num_pairs_ell, args.nell)
+        header[3]['value'] = args.nell
+
         results.write(
-            [r_ell, z_ell, num_pairs_ell],
-            names=['RT', 'Z', 'NB'],
-            comment=['Radial separation', 'Redshift', 'Number of pairs'],
-            units=['h^-1 Mpc', '', ''],
+            [rp_ell, r_ell, z_ell, num_pairs_ell],
+            names=['RP', 'RT', 'Z', 'NB'],
+            comment=['Multipole', 'Radial separation', 'Redshift', 'Number of pairs'],
+            units=['', 'h^-1 Mpc', '', ''],
             header=header,
             extname='ATTRI_ELL')
 
-        ells = 2 * np.arange(args.nell)
         xi_ells, we_ells = cf.calculate_xi_ell(ells, xi_list, weights_list)
         results.write(
             [healpix_list, we_ells, xi_ells],

--- a/py/picca/bin/picca_cf.py
+++ b/py/picca/bin/picca_cf.py
@@ -87,6 +87,11 @@ def main(cmdargs=None):
                         default=50,
                         required=False,
                         help='Number of r-transverse bins')
+
+    parser.add_argument('--rmu-binning', action="store_true",
+                        help=('Estimate in r,mu binning. np becomes mu bins.'
+                              ' nt becomes r bins. rp min max is always 0, 1')
+                        )
     
     parser.add_argument('--zerr-cut-deg',
                         type=float,
@@ -250,6 +255,11 @@ def main(cmdargs=None):
 
     if args.nproc is None:
         args.nproc = cpu_count() // 2
+
+    cf.rmu_binning = args.rmu_binning
+    if cf.rmu_binning:
+        args.rp_min = 0
+        args.rp_max = 1
 
     # setup variables in module cf
     cf.r_par_max = args.rp_max
@@ -435,7 +445,8 @@ def main(cmdargs=None):
     ]
     results.write(
         [r_par, r_trans, z, num_pairs],
-        names=['RP', 'RT', 'Z', 'NB'],
+        names=['MU' if cf.rmu_binning else 'RP',
+               'R' if cf.rmu_binning else 'RT', 'Z', 'NB'],
         comment=['R-parallel', 'R-transverse', 'Redshift', 'Number of pairs'],
         units=['h^-1 Mpc', 'h^-1 Mpc', '', ''],
         header=header,

--- a/py/picca/bin/picca_cf.py
+++ b/py/picca/bin/picca_cf.py
@@ -445,10 +445,11 @@ def main(cmdargs=None):
     ]
     results.write(
         [r_par, r_trans, z, num_pairs],
-        names=['MU' if cf.rmu_binning else 'RP',
-               'R' if cf.rmu_binning else 'RT', 'Z', 'NB'],
-        comment=['R-parallel', 'R-transverse', 'Redshift', 'Number of pairs'],
-        units=['h^-1 Mpc', 'h^-1 Mpc', '', ''],
+        names=['RP', 'RT', 'Z', 'NB'],
+        comment=['R-parallel' if not cf.rmu_binning else 'Mu',
+                 'R-transverse' if not cf.rmu_binning else 'Radial separation',
+                 'Redshift', 'Number of pairs'],
+        units=['h^-1 Mpc' if not cf.rmu_binning else '', 'h^-1 Mpc', '', ''],
         header=header,
         extname='ATTRI')
 

--- a/py/picca/bin/picca_cf.py
+++ b/py/picca/bin/picca_cf.py
@@ -446,6 +446,10 @@ def main(cmdargs=None):
         'name': "BLINDING",
         'value': blinding,
         'comment': 'String specifying the blinding strategy'
+    }, {
+        'name': "RMU_BIN",
+        'value': cf.rmu_binning,
+        'comment': 'True if binned in r, mu'
     }
     ]
     results.write(
@@ -471,39 +475,6 @@ def main(cmdargs=None):
                   comment=['Healpix index', 'Sum of weight', 'Correlation'],
                   header=header2,
                   extname='COR')
-
-    if cf.rmu_binning and args.nell > 0:
-        sum_weights = sum_weights.reshape(args.np, args.nt)
-        sum_sum_weights = sum_weights.sum(0)
-        r_trans = r_trans.reshape(args.np, args.nt)
-        z = z.reshape(args.np, args.nt)
-        # Is there a multipole dependent weighting for effective r and z?
-        r_ell = np.sum(sum_weights * r_trans, 0) / sum_sum_weights
-        z_ell = np.sum(sum_weights * z, 0) / sum_sum_weights
-        num_pairs_ell = num_pairs.reshape(args.np, args.nt).sum(0)
-        ells = 2 * np.arange(args.nell)
-        rp_ell = np.repeat(ells, args.nt)
-        r_ell = np.tile(r_ell, args.nell)
-        z_ell = np.tile(z_ell, args.nell)
-        num_pairs_ell = np.tile(num_pairs_ell, args.nell)
-        header[3]['value'] = args.nell
-
-        results.write(
-            [rp_ell, r_ell, z_ell, num_pairs_ell],
-            names=['RP', 'RT', 'Z', 'NB'],
-            comment=['Multipole', 'Radial separation', 'Redshift', 'Number of pairs'],
-            units=['', 'h^-1 Mpc', '', ''],
-            header=header,
-            extname='ATTRI_ELL')
-
-        xi_ells, we_ells = cf.calculate_xi_ell(ells, xi_list, weights_list)
-        results.write(
-            [healpix_list, we_ells, xi_ells],
-            names=['HEALPID', 'WE', xi_list_name],
-            comment=['Healpix index', 'Sum of weight', 'Correlation'],
-            header=header2,
-            extname='COR_ELL')
-    results.close()
 
     t3 = time.time()
     userprint(f'picca_cf.py - Time total : {(t3-t0)/60:.3f} minutes')

--- a/py/picca/bin/picca_dmat.py
+++ b/py/picca/bin/picca_dmat.py
@@ -91,13 +91,18 @@ def main(cmdargs=None):
                         required=False,
                         help='Number of r-transverse bins')
 
+    parser.add_argument('--rmu-binning', action="store_true",
+                        help=('Estimate in r,mu binning. np becomes mu bins.'
+                              ' nt becomes r bins. rp min max is always 0, 1')
+                        )
+
     parser.add_argument(
         '--coef-binning-model',
         type=int,
         default=1,
         required=False,
         help=('Coefficient multiplying np and nt to get finner binning for the '
-              'model'))
+              'model. Only nt is multiplied in rmu-binning'))
 
     parser.add_argument('--zerr-cut-deg',
                         type=float,
@@ -272,6 +277,13 @@ def main(cmdargs=None):
     userprint("nproc", args.nproc)
 
     # setup variables in module cf
+    cf.rmu_binning = args.rmu_binning
+    if cf.rmu_binning:
+        args.rp_min = 0
+        args.rp_max = 1
+        cf.num_model_bins_r_par = args.np
+    else:
+        cf.num_model_bins_r_par = args.np * args.coef_binning_model
     cf.r_par_max = args.rp_max
     cf.r_par_min = args.rp_min
     cf.r_trans_max = args.rt_max
@@ -279,7 +291,6 @@ def main(cmdargs=None):
     cf.z_cut_min = args.z_cut_min
     cf.num_bins_r_par = args.np
     cf.num_bins_r_trans = args.nt
-    cf.num_model_bins_r_par = args.np * args.coef_binning_model
     cf.num_model_bins_r_trans = args.nt * args.coef_binning_model
     cf.nside = args.nside
 
@@ -502,6 +513,10 @@ def main(cmdargs=None):
             'name': "BLINDING",
             'value': blinding,
             'comment': 'String specifying the blinding strategy'
+        }, {
+            'name': "RMU_BIN",
+            'value': cf.rmu_binning,
+            'comment': 'True if binned in r, mu'
         }
         ]
     dmat_name = "DM"

--- a/py/picca/bin/picca_export.py
+++ b/py/picca/bin/picca_export.py
@@ -49,13 +49,13 @@ def main(cmdargs=None):
 
     parser.add_argument('--multipoles', action="store_true",
                         help='Use multipole extension')
-    parser.add_argument('--nell-model-max', type=int, default=6,
-                        help=('Number of multipoles for the model'
-                              ' if rmu-binning')
+    parser.add_argument('--lmax-model', type=int, default=6,
+                        help=('Max multipole ell for the model if rmu-binning'
+                              '. Note odd multipoles are removed from auto.')
                         )
-    parser.add_argument('--nell-out-max', type=int, default=10,
-                        help=('Number of multipoles for the output'
-                              ' if rmu-binning')
+    parser.add_argument('--lmax-data', type=int, default=10,
+                        help=('Max multipole ell for the output if rmu-binning'
+                              '. Note odd multipoles are removed from auto.')
                         )
 
     parser.add_argument(
@@ -151,7 +151,7 @@ def main(cmdargs=None):
         args.do_not_smooth_cov = True
         assert head['RMU_BIN']
 
-        ells_out = np.arange(args.nell_out_max + 1)
+        ells_out = np.arange(args.lmax_out + 1)
         if not is_x_correlation:
             ells_out = ells_out[ells_out % 2 == 0]
 
@@ -266,14 +266,14 @@ def main(cmdargs=None):
 
         if args.multipoles:
             assert head_dmat['RMU_BIN']
-            ells_model = np.arange(args.nell_model_max + 1)
+            ells_model = np.arange(args.lmax_model + 1)
             if not is_x_correlation:
                 ells_model = ells_model[ells_model % 2 == 0]
             nell_model = ells_model.size
 
             # From model multipoles to transverse-radial interpolation matrix.
             ell_to_tr_matrix = legvander(
-                r_par_dmat, args.nell_model_max)[:, ells_model]
+                r_par_dmat, args.lmax_model)[:, ells_model]
             cols = np.floor(r_trans_dmat / dr_dmat).astype(int)
             cols = np.repeat(cols, nell_model) + np.tile(
                 np.arange(nell_model) * nr_dmat, cols.size)

--- a/py/picca/bin/picca_export.py
+++ b/py/picca/bin/picca_export.py
@@ -326,6 +326,11 @@ def main(cmdargs=None):
 
             dmat = tr_to_ell_matrix.dot(dmat)
             del tr_to_ell_matrix
+
+            header_multipole.append({
+                'name': 'NL_MODEL',
+                'value': nell_model,
+                'comment': 'Number of model multipoles'})
     else:
         dmat = np.eye(len(xi))
         r_par_dmat = r_par.copy()

--- a/py/picca/bin/picca_export.py
+++ b/py/picca/bin/picca_export.py
@@ -12,7 +12,8 @@ import sys
 from numpy.polynomial.legendre import legvander
 from scipy.sparse import coo_array
 
-from picca.utils import smooth_cov, compute_cov, calculate_xi_ell
+from picca.utils import (
+    smooth_cov, compute_cov, calculate_xi_ell, get_legendre_bins)
 from picca.utils import userprint
 
 # TODO: add tags here when we are allowed to unblind them
@@ -306,18 +307,9 @@ def main(cmdargs=None):
             # From transverse-radial binning to multipoles matrix
             assert xi.size == nell_out * num_bins_r_trans
             tr_to_ell_matrix = np.zeros((xi.size, dmat.shape[0]))
-            mu1 = -1.0 if is_x_correlation else 0.0
-            dmu = (1.0 - mu1) / num_bins_r_par
-            muc = np.arange(num_bins_r_par) * dmu + mu1 + dmu / 2
 
-            if is_x_correlation:
-                dmu /= 2
-
-            leg_ells = [
-                np.polynomial.legendre.Legendre.basis(ell)(muc)
-                * dmu * (2 * ell + 1)
-                for ell in ells_out]
-            del mu1, dmu, muc
+            leg_ells = get_legendre_bins(
+                ells_out, num_bins_r_par, is_x_correlation)
 
             for i in range(xi.size):
                 ell = i // num_bins_r_trans

--- a/py/picca/bin/picca_export.py
+++ b/py/picca/bin/picca_export.py
@@ -275,7 +275,8 @@ def main(cmdargs=None):
             ell_to_tr_matrix = legvander(
                 r_par_dmat, args.nell_model_max)[:, ells_model]
             cols = np.floor(r_trans_dmat / dr_dmat).astype(int)
-            cols = np.hstack([cols + j * nr_dmat for j in range(nell_model)])
+            cols = np.repeat(cols, nell_model) + np.tile(
+                np.arange(nell_model) * nr_dmat, cols.size)
             rows = np.repeat(np.arange(dmat.shape[1]), nell_model)
             ell_to_tr_matrix = coo_array(
                 (ell_to_tr_matrix.ravel(), (rows, cols)),
@@ -308,9 +309,8 @@ def main(cmdargs=None):
 
             for i in range(xi.size):
                 ell = i // num_bins_r_trans
-                j1 = (i % num_bins_r_trans) * num_bins_r_par
-                j2 = j1 + num_bins_r_par
-                tr_to_ell_matrix[i, j1:j2] = leg_ells[ell]
+                j1 = i % num_bins_r_trans
+                tr_to_ell_matrix[i, j1::num_bins_r_trans] = leg_ells[ell]
 
             dmat = tr_to_ell_matrix.dot(dmat)
             del tr_to_ell_matrix

--- a/py/picca/bin/picca_export.py
+++ b/py/picca/bin/picca_export.py
@@ -47,11 +47,11 @@ def main(cmdargs=None):
     parser.add_argument('--multipoles', action="store_true",
                         help='Use multipole extension')
     parser.add_argument('--nell-model-max', type=int, default=6,
-                        help=('Number of even multipoles for the model'
+                        help=('Number of multipoles for the model'
                               ' if rmu-binning')
                         )
     parser.add_argument('--nell-out-max', type=int, default=10,
-                        help=('Number of even multipoles for the output'
+                        help=('Number of multipoles for the output'
                               ' if rmu-binning')
                         )
 

--- a/py/picca/bin/picca_export.py
+++ b/py/picca/bin/picca_export.py
@@ -151,7 +151,7 @@ def main(cmdargs=None):
         args.do_not_smooth_cov = True
         assert head['RMU_BIN']
 
-        ells_out = np.arange(args.lmax_out + 1)
+        ells_out = np.arange(args.lmax_data + 1)
         if not is_x_correlation:
             ells_out = ells_out[ells_out % 2 == 0]
 

--- a/py/picca/bin/picca_export.py
+++ b/py/picca/bin/picca_export.py
@@ -97,7 +97,7 @@ def main(cmdargs=None):
     else:
         ext = 1
 
-    r_par = np.array(hdul[1]['RP'][:])
+    r_par = np.array(hdul[ext]['RP'][:])
     r_trans = np.array(hdul[ext]['RT'][:])
     z = np.array(hdul[ext]['Z'][:])
     num_pairs = np.array(hdul[ext]['NB'][:])
@@ -110,7 +110,7 @@ def main(cmdargs=None):
         xi = np.array(hdul[ext + 1]['DA'][:])
         data_name = 'DA'
 
-    head = hdul[1].read_header()
+    head = hdul[ext].read_header()
     num_bins_r_par = head['NP']
     num_bins_r_trans = head['NT']
     r_trans_max = head['RTMAX']

--- a/py/picca/bin/picca_export.py
+++ b/py/picca/bin/picca_export.py
@@ -44,6 +44,9 @@ def main(cmdargs=None):
         help=('Distortion matrix produced via picca_dmat.py, picca_xdmat.py... '
               '(if not provided will be identity)'))
 
+    parser.add_argument('--multipoles', action="store_true",
+                        help='Use multipole extension')
+
     parser.add_argument(
         '--cov',
         type=str,
@@ -87,18 +90,24 @@ def main(cmdargs=None):
     args = parser.parse_args(cmdargs)
 
     hdul = fitsio.FITS(args.data)
+    if args.multipoles:
+        ext = 3
+        userprint("Smoothing is turned off for multipoles")
+        args.do_not_smooth_cov = True
+    else:
+        ext = 1
 
     r_par = np.array(hdul[1]['RP'][:])
-    r_trans = np.array(hdul[1]['RT'][:])
-    z = np.array(hdul[1]['Z'][:])
-    num_pairs = np.array(hdul[1]['NB'][:])
-    weights = np.array(hdul[2]['WE'][:])
+    r_trans = np.array(hdul[ext]['RT'][:])
+    z = np.array(hdul[ext]['Z'][:])
+    num_pairs = np.array(hdul[ext]['NB'][:])
+    weights = np.array(hdul[ext + 1]['WE'][:])
 
-    if 'DA_BLIND' in hdul[2].get_colnames():
-        xi = np.array(hdul[2]['DA_BLIND'][:])
+    if 'DA_BLIND' in hdul[ext + 1].get_colnames():
+        xi = np.array(hdul[ext + 1]['DA_BLIND'][:])
         data_name = 'DA_BLIND'
     else:
-        xi = np.array(hdul[2]['DA'][:])
+        xi = np.array(hdul[ext + 1]['DA'][:])
         data_name = 'DA'
 
     head = hdul[1].read_header()

--- a/py/picca/bin/picca_export.py
+++ b/py/picca/bin/picca_export.py
@@ -175,8 +175,20 @@ def main(cmdargs=None):
 
         xi, weights = calculate_xi_ell(
             ells_out, xi, weights, num_bins_r_par, is_x_correlation)
+        header_multipole = [
+            {'name': 'MLTPOLE',
+             'value': True,
+             'comment': 'Specifying if in multipoles.'},
+            {'name': 'NL_DATA',
+             'value': nell_out,
+             'comment': 'Number of output multipoles'}
+        ]
     else:
         ells_out = None
+        header_multipole = [
+            {'name': 'MLTPOLE',
+             'value': False,
+             'comment': 'Specifying if in multipoles.'}]
 
     if args.cov is not None:
         userprint(("INFO: The covariance-matrix will be read from file: "
@@ -363,8 +375,12 @@ def main(cmdargs=None):
         'name': 'WL',
         'value': head['WL'],
         'comment': 'Equation of state of dark energy of fiducial LambdaCDM cosmology'
-    },
-    ]
+    }, {
+        'name': "RMU_BIN",
+        'value': head['RMU_BIN'] and not args.multipoles,
+        'comment': 'True if binned in r, mu'
+    }
+    ] + header_multipole
     comment = [
         'R-parallel', 'R-transverse', 'Redshift', 'Correlation',
         'Covariance matrix', 'Distortion matrix', 'Number of pairs'

--- a/py/picca/bin/picca_xcf.py
+++ b/py/picca/bin/picca_xcf.py
@@ -479,6 +479,10 @@ def main(cmdargs=None):
         'name': "BLINDING",
         'value': blinding,
         'comment': 'String specifying the blinding strategy'
+    }, {
+        'name': "RMU_BIN",
+        'value': cf.rmu_binning,
+        'comment': 'True if binned in r, mu'
     }
     ]
     results.write(
@@ -504,38 +508,6 @@ def main(cmdargs=None):
                   comment=['Healpix index', 'Sum of weight', 'Correlation'],
                   header=header2,
                   extname='COR')
-
-    if xcf.rmu_binning and args.nell > 0:
-        sum_weights = sum_weights.reshape(args.np, args.nt)
-        sum_sum_weights = sum_weights.sum(0)
-        r_trans = r_trans.reshape(args.np, args.nt)
-        z = z.reshape(args.np, args.nt)
-        # Is there a multipole dependent weighting for effective r and z?
-        r_ell = np.sum(sum_weights * r_trans, 0) / sum_sum_weights
-        z_ell = np.sum(sum_weights * z, 0) / sum_sum_weights
-        num_pairs_ell = num_pairs.reshape(args.np, args.nt).sum(0)
-        ells = np.arange(args.nell)
-        rp_ell = np.repeat(ells, args.nt)
-        r_ell = np.tile(r_ell, args.nell)
-        z_ell = np.tile(z_ell, args.nell)
-        num_pairs_ell = np.tile(num_pairs_ell, args.nell)
-        header[3]['value'] = args.nell
-
-        results.write(
-            [rp_ell, r_ell, z_ell, num_pairs_ell],
-            names=['RP', 'RT', 'Z', 'NB'],
-            comment=['Multipole', 'Radial separation', 'Redshift', 'Number of pairs'],
-            units=['', 'h^-1 Mpc', '', ''],
-            header=header,
-            extname='ATTRI_ELL')
-
-        xi_ells, we_ells = xcf.calculate_xi_ell(ells, xi_list, weights_list)
-        results.write(
-            [healpix_list, we_ells, xi_ells],
-            names=['HEALPID', 'WE', da_name],
-            comment=['Healpix index', 'Sum of weight', 'Correlation'],
-            header=header2,
-            extname='COR_ELL')
 
     results.close()
 

--- a/py/picca/bin/picca_xcf.py
+++ b/py/picca/bin/picca_xcf.py
@@ -105,10 +105,6 @@ def main(cmdargs=None):
                               ' nt becomes r bins. rp min max is always -1, 1')
                         )
 
-    parser.add_argument('--nell', type=int, default=10,
-                        help='Number of multipoles to calculate if rmu-binning'
-                        )
-
     parser.add_argument('--z-min-obj',
                         type=float,
                         default=0,

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -205,6 +205,54 @@ def compute_xi(healpixs):
     return weights, xi, r_par, r_trans, z, num_pairs
 
 
+def calculate_xi_ell(ells, xi_list, weights_list):
+    """Calculates the multipoles and their approximate weights per healpix.
+    Args:
+        ells: list(int)
+            List of multipoles
+        xi_list: list(cf)
+            List of correlation functions in rperp, rpara scheme for all hpx
+        weights_list: list(weight)
+            Weights for all healpixels
+
+    Returns:
+        xi_ells: np.ndarray
+            CF multipoles for all hpx
+        weight_ells: np.ndarray
+            Weights for each multipole for all hpx
+    """
+    dmu = (r_par_max - r_par_min) / num_bins_r_par
+    muc = np.arange(num_bins_r_par) * dmu + r_par_min + dmu / 2
+    leg_ells = [
+        np.polynomial.legendre.Legendre.basis(ell)(muc)
+        for ell in ells]
+
+    if x_correlation:
+        dmu /= 2
+
+    xi_ells = []
+    for xi in xi_list:
+        xi = xi.reshape(num_bins_r_par, num_bins_r_trans)
+        xi_ell = [
+            (xi * leg_ells[i][:, None]).sum(0) * dmu * (2 * ell + 1)
+            for i, ell in enumerate(ells)
+        ]
+        xi_ells.append(np.hstack(xi_ell))
+
+    # Approximate weights based on variance propagation rule.
+    weight_ells = []
+    leg_ells = [_**2 for _ in leg_ells]
+    for we in weights_list:
+        we = 1.0 / we.reshape(num_bins_r_par, num_bins_r_trans)
+        we_ell = [
+            (we * leg_ells[i][:, None]).sum(0) * (dmu * (2 * ell + 1))**2
+            for i, ell in enumerate(ells)
+        ]
+        weight_ells.append(1.0 / np.hstack(we_ell))
+
+    return np.vstack(xi_ells), np.vstack(weight_ells)
+
+
 @njit
 def compute_xi_forest_pairs_fast(z1, r_comov1, dist_m1, weights1, delta1, z_qso_1,
                                  z2, r_comov2, dist_m2, weights2, delta2, z_qso_2,

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -524,6 +524,9 @@ def compute_dmat_forest_pairs_fast(log_lambda1, log_lambda2, r_comov1, r_comov2,
 
             r_par = (r_comov1[i] - r_comov2[j]) * np.cos(ang / 2)
             r_trans = (dist_m1[i] + dist_m2[j]) * np.sin(ang / 2)
+            if rmu_binning:
+                r_trans = np.sqrt(r_trans**2 + r_par**2)
+                r_par /= r_trans
             if not x_correlation:
                 r_par = np.abs(r_par)
             if (r_par >= r_par_max or r_trans >= r_trans_max or

--- a/py/picca/cf.py
+++ b/py/picca/cf.py
@@ -57,6 +57,7 @@ cosmo = None
 reject = None
 lock = None
 x_correlation = False
+rmu_binning = False
 ang_correlation = False
 remove_same_half_plate_close_pairs = False
 
@@ -287,6 +288,9 @@ def compute_xi_forest_pairs_fast(z1, r_comov1, dist_m1, weights1, delta1, z_qso_
             else:
                 r_par = (r_comov1[i] - r_comov2[j]) * np.cos(ang / 2)
                 r_trans = (dist_m1[i] + dist_m2[j]) * np.sin(ang / 2)
+                if rmu_binning:
+                    r_trans = np.sqrt(r_trans**2 + r_par**2)
+                    r_par /= r_trans
                 if not x_correlation:
                     r_par = np.abs(r_par)
 

--- a/py/picca/utils.py
+++ b/py/picca/utils.py
@@ -28,6 +28,33 @@ def userprint(*args, **kwds):
     sys.stdout.flush()
 
 
+def get_legendre_bins(ells, nmu, x_correlation):
+    """Return mu-bin averaged Legendre multipoles.
+    Args:
+        ells: list(int)
+            List of multipoles
+        nmu: int
+            Number of mu bins
+        x_correlation: bool
+            True if cross-correlations. mu's start from -1.
+
+    Returns:
+        leg_ells: list(np.ndarray)
+            Bin averaged Legendre multipoles. Array of size nmu.
+    """
+    mu1 = -1.0 if x_correlation else 0.0
+    mue = np.linspace(mu1, 1.0, nmu + 1)
+    f = 0.5 if x_correlation else 1.0
+
+    leg_ells = [
+        np.polynomial.legendre.Legendre.basis(ell).integ()(mue)
+        * f * (2 * ell + 1)
+        for ell in ells]
+    leg_ells = [le[1:] - le[:-1] for le in leg_ells]
+
+    return leg_ells
+
+
 def calculate_xi_ell(ells, xi_list, weights_list, nmu, x_correlation=False):
     """Calculates the multipoles and their approximate weights per healpix.
     Args:
@@ -37,6 +64,10 @@ def calculate_xi_ell(ells, xi_list, weights_list, nmu, x_correlation=False):
             List of correlation functions in rperp, rpara scheme for all hpx
         weights_list: list(weight)
             Weights for all healpixels
+        nmu: int
+            Number of mu bins
+        x_correlation: bool
+            True if cross-correlations. mu's start from -1.
 
     Returns:
         xi_ells: np.ndarray
@@ -44,15 +75,7 @@ def calculate_xi_ell(ells, xi_list, weights_list, nmu, x_correlation=False):
         weight_ells: np.ndarray
             Weights for each multipole for all hpx
     """
-    mu1 = -1.0 if x_correlation else 0.0
-    dmu = (1.0 - mu1) / nmu
-    muc = np.arange(nmu) * dmu + mu1 + dmu / 2
-    leg_ells = [
-        np.polynomial.legendre.Legendre.basis(ell)(muc)
-        for ell in ells]
-
-    if x_correlation:
-        dmu /= 2
+    leg_ells = get_legendre_bins(ells, nmu, x_correlation)
 
     nr = xi_list[0].size // nmu
     assert nmu * nr == xi_list[0].size
@@ -60,21 +83,15 @@ def calculate_xi_ell(ells, xi_list, weights_list, nmu, x_correlation=False):
     xi_ells = []
     for xi in xi_list:
         xi = xi.reshape(nmu, nr)
-        xi_ell = [
-            (xi * leg_ells[i][:, None]).sum(0) * dmu * (2 * ell + 1)
-            for i, ell in enumerate(ells)
-        ]
+        xi_ell = [(xi * le[:, None]).sum(0) for le in leg_ells]
         xi_ells.append(np.hstack(xi_ell))
 
     # Approximate weights based on variance propagation rule.
     weight_ells = []
-    leg_ells = [_**2 for _ in leg_ells]
+    leg_ells = [le**2 for le in leg_ells]
     for we in weights_list:
         we = 1.0 / we.reshape(nmu, nr)
-        we_ell = [
-            (we * leg_ells[i][:, None]).sum(0) * (dmu * (2 * ell + 1))**2
-            for i, ell in enumerate(ells)
-        ]
+        we_ell = [(we * le[:, None]).sum(0) for le in leg_ells]
         weight_ells.append(1.0 / np.hstack(we_ell))
 
     return np.vstack(xi_ells), np.vstack(weight_ells)

--- a/py/picca/xcf.py
+++ b/py/picca/xcf.py
@@ -53,6 +53,7 @@ reject = None
 lock = None
 
 cosmo = None
+rmu_binning = False
 ang_correlation = False
 
 # variables for distortion matrix
@@ -194,6 +195,51 @@ def compute_xi(healpixs):
     return weights, xi, r_par, r_trans, z, num_pairs
 
 
+def calculate_xi_ell(ells, xi_list, weights_list):
+    """Calculates the multipoles and their approximate weights per healpix.
+    Args:
+        ells: list(int)
+            List of multipoles
+        xi_list: list(cf)
+            List of correlation functions in rperp, rpara scheme for all hpx
+        weights_list: list(weight)
+            Weights for all healpixels
+
+    Returns:
+        xi_ells: np.ndarray
+            CF multipoles for all hpx
+        weight_ells: np.ndarray
+            Weights for each multipole for all hpx
+    """
+    dmu = (r_par_max - r_par_min) / num_bins_r_par
+    muc = np.arange(num_bins_r_par) * dmu + r_par_min + dmu / 2
+    leg_ells = [
+        np.polynomial.legendre.Legendre.basis(ell)(muc)
+        for ell in ells]
+
+    xi_ells = []
+    for xi in xi_list:
+        xi = xi.reshape(num_bins_r_par, num_bins_r_trans)
+        xi_ell = [
+            (xi * leg_ells[i][:, None]).sum(0) * dmu * (2 * ell + 1) / 2
+            for i, ell in enumerate(ells)
+        ]
+        xi_ells.append(np.hstack(xi_ell))
+
+    # Approximate weights based on variance propagation rule.
+    weight_ells = []
+    leg_ells = [_**2 for _ in leg_ells]
+    for we in weights_list:
+        we = 1.0 / we.reshape(num_bins_r_par, num_bins_r_trans)
+        we_ell = [
+            (we * leg_ells[i][:, None]).sum(0) * (dmu * (2 * ell + 1) / 2)**2
+            for i, ell in enumerate(ells)
+        ]
+        weight_ells.append(1.0 / np.hstack(we_ell))
+
+    return np.vstack(xi_ells), np.vstack(weight_ells)
+
+
 @njit
 def compute_xi_forest_pairs_fast(z1, r_comov1, dist_m1, weights1, delta1, z2,
                                  r_comov2, dist_m2, weights2, ang, rebin_weight,
@@ -249,6 +295,10 @@ def compute_xi_forest_pairs_fast(z1, r_comov1, dist_m1, weights1, delta1, z2,
             else:
                 r_par = (r_comov1[i] - r_comov2[j]) * np.cos(ang[j] / 2)
                 r_trans = (dist_m1[i] + dist_m2[j]) * np.sin(ang[j] / 2)
+
+            if rmu_binning:
+                r_trans = np.sqrt(r_trans**2 + r_par**2)
+                r_par /= r_trans
 
             if (r_par >= r_par_max or r_trans >= r_trans_max or
                     r_par <= r_par_min):
@@ -401,6 +451,10 @@ def compute_dmat_forest_pairs_fast(log_lambda1, r_comov1, dist_m1, z1, weights1,
                 continue
             r_par = (r_comov1[i] - r_comov2[j]) * np.cos(ang[j] / 2)
             r_trans = (dist_m1[i] + dist_m2[j]) * np.sin(ang[j] / 2)
+            if rmu_binning:
+                r_trans = np.sqrt(r_trans**2 + r_par**2)
+                r_par /= r_trans
+
             if (r_par >= r_par_max or r_trans >= r_trans_max or
                     r_par < r_par_min):
                 continue

--- a/py/picca/xcf.py
+++ b/py/picca/xcf.py
@@ -195,51 +195,6 @@ def compute_xi(healpixs):
     return weights, xi, r_par, r_trans, z, num_pairs
 
 
-def calculate_xi_ell(ells, xi_list, weights_list):
-    """Calculates the multipoles and their approximate weights per healpix.
-    Args:
-        ells: list(int)
-            List of multipoles
-        xi_list: list(cf)
-            List of correlation functions in rperp, rpara scheme for all hpx
-        weights_list: list(weight)
-            Weights for all healpixels
-
-    Returns:
-        xi_ells: np.ndarray
-            CF multipoles for all hpx
-        weight_ells: np.ndarray
-            Weights for each multipole for all hpx
-    """
-    dmu = (r_par_max - r_par_min) / num_bins_r_par
-    muc = np.arange(num_bins_r_par) * dmu + r_par_min + dmu / 2
-    leg_ells = [
-        np.polynomial.legendre.Legendre.basis(ell)(muc)
-        for ell in ells]
-
-    xi_ells = []
-    for xi in xi_list:
-        xi = xi.reshape(num_bins_r_par, num_bins_r_trans)
-        xi_ell = [
-            (xi * leg_ells[i][:, None]).sum(0) * dmu * (2 * ell + 1) / 2
-            for i, ell in enumerate(ells)
-        ]
-        xi_ells.append(np.hstack(xi_ell))
-
-    # Approximate weights based on variance propagation rule.
-    weight_ells = []
-    leg_ells = [_**2 for _ in leg_ells]
-    for we in weights_list:
-        we = 1.0 / we.reshape(num_bins_r_par, num_bins_r_trans)
-        we_ell = [
-            (we * leg_ells[i][:, None]).sum(0) * (dmu * (2 * ell + 1) / 2)**2
-            for i, ell in enumerate(ells)
-        ]
-        weight_ells.append(1.0 / np.hstack(we_ell))
-
-    return np.vstack(xi_ells), np.vstack(weight_ells)
-
-
 @njit
 def compute_xi_forest_pairs_fast(z1, r_comov1, dist_m1, weights1, delta1, z2,
                                  r_comov2, dist_m2, weights2, ang, rebin_weight,


### PR DESCRIPTION
This branch introduces the capability to estimate the correlation function in the (r, mu) grid. The multipoles can be exported using `picca_export.py`, although it is unclear if this is the correct place to do so. 