### PR TITLE
Make sure that blind_corr_type is the one expected in the blinding template file

### DIFF
--- a/py/picca/bin/picca_export.py
+++ b/py/picca/bin/picca_export.py
@@ -429,9 +429,9 @@ def main(cmdargs=None):
             blind_corr_type = args.blind_corr_type
             # match name expected in blinding template file
             if blind_corr_type == 'qsoxlya':
-                blind_corr_type == 'lyaxqso'
+                blind_corr_type = 'lyaxqso'
             if blind_corr_type == 'qsoxlyb':
-                blind_corr_type == 'lybxqso'
+                blind_corr_type = 'lybxqso'
 
         # Check type of correlation and get size and regular binning
         if blind_corr_type in ['lyaxlya', 'lyaxlyb']:

--- a/py/picca/bin/picca_export.py
+++ b/py/picca/bin/picca_export.py
@@ -101,7 +101,7 @@ def main(cmdargs=None):
     parser.add_argument(
         '--blind-corr-type',
         default=None,
-        choices=['lyaxlya', 'lyaxlyb', 'qsoxlya', 'qsoxlyb'],
+        choices=['lyaxlya', 'lyaxlyb', 'qsoxlya', 'qsoxlyb', 'lyaxqso', 'lybxqso'],
         help='Type of correlation. Required to apply blinding in DESI')
 
     args = parser.parse_args(cmdargs)
@@ -424,19 +424,26 @@ def main(cmdargs=None):
                              f" Found {blinding}.")
 
         if args.blind_corr_type is None:
-            raise ValueError("Blinding requires argument --blind_corr_type.")
+            raise ValueError("Blinding requires argument --blind-corr-type.")
+        else:
+            blind_corr_type = args.blind_corr_type
+            # match name expected in blinding template file
+            if blind_corr_type == 'qsoxlya':
+                blind_corr_type == 'lyaxqso'
+            if blind_corr_type == 'qsoxlyb':
+                blind_corr_type == 'lybxqso'
 
         # Check type of correlation and get size and regular binning
-        if args.blind_corr_type in ['lyaxlya', 'lyaxlyb']:
+        if blind_corr_type in ['lyaxlya', 'lyaxlyb']:
             corr_size = 2500
             rp_interp_grid = np.arange(2., 202., 4)
             rt_interp_grid = np.arange(2., 202., 4)
-        elif args.blind_corr_type in ['qsoxlya', 'qsoxlyb']:
+        elif blind_corr_type in ['lyaxqso', 'lybxqso']:
             corr_size = 5000
             rp_interp_grid = np.arange(-197.99, 202.01, 4)
             rt_interp_grid = np.arange(2., 202, 4)
         else:
-            raise ValueError("Unknown correlation type: {}".format(args.blind_corr_type))
+            raise ValueError("Unknown correlation type: {}".format(blind_corr_type))
 
         if corr_size == num_bins_r_par * num_bins_r_trans:
             # Read the blinding file and get the right template
@@ -449,7 +456,7 @@ def main(cmdargs=None):
             raise RuntimeError("Missing blinding file. Make sure you are running at"
                                " NERSC or contact picca developers")
         blinding_file = h5py.File(blinding_filename, 'r')
-        hex_diff = np.array(blinding_file['blinding'][args.blind_corr_type]).astype(str)
+        hex_diff = np.array(blinding_file['blinding'][blind_corr_type]).astype(str)
         diff_grid = np.array([float.fromhex(x) for x in hex_diff])
 
         if corr_size == num_bins_r_par * num_bins_r_trans:


### PR DESCRIPTION
Somehow in DR3 the blinding file expects `lyaxqso` and `lybxqso`, but picca_export.py insisted on using `qsoxlya` and `qsoxlyb`. 

I didn't want to modify the template file, and I didn't want to break other people's scripts using picca_export, so I ended up renaming the variable internally in the code before reading the blinding template file.